### PR TITLE
Fix loading of @build_bazel_rules_nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ node_repositories(package_json = ["//:package.json"])
 # Include @bazel/typescript in package.json#devDependencies
 local_repository(
     name = "build_bazel_rules_typescript",
-    path = "node_modules/rules_typescript",
+    path = "node_modules/@bazel/typescript",
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git_repository(
     tag = "0.0.1", # check for the latest tag when you install
 )
 
-load("@build_bazel_rules_typescript//:defs.bzl", "node_repositories")
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
 
 node_repositories(package_json = ["//:package.json"])
 


### PR DESCRIPTION
This is the fix I had to do in my client to get the Typescript rules to work.
I believe it came from when the nodejs rules were together with the ts ones.