### PR TITLE
Switch devmode to UMD format.

### DIFF
--- a/examples/es5_output/BUILD.bazel
+++ b/examples/es5_output/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//:defs.bzl", "ts_library")
+load(":es5_consumer.bzl", "es5_consumer")
+
+genrule(
+  name = "generated_ts",
+  outs = ["generated.ts"],
+  cmd = "echo 'export const gen = 1;' > $@",
+)
+
+ts_library(
+    name = "lib",
+    srcs = glob(["*.ts"]) + [":generated.ts"],
+    deps = ["//examples/es5_output/rand"],
+)
+
+es5_consumer(
+    name = "es5_output",
+    deps = [":lib"],
+)
+
+sh_test(
+    name = "es5_output_test",
+    srcs = ["es5_output_test.sh"],
+    data = [":es5_output"],
+)

--- a/examples/es5_output/a.ts
+++ b/examples/es5_output/a.ts
@@ -1,0 +1,2 @@
+import {rand} from './rand/rand';
+export const a = rand();

--- a/examples/es5_output/b.ts
+++ b/examples/es5_output/b.ts
@@ -1,0 +1,4 @@
+import {a} from './a';
+import {gen} from './generated';
+
+console.log(a, gen);

--- a/examples/es5_output/es5_consumer.bzl
+++ b/examples/es5_output/es5_consumer.bzl
@@ -1,0 +1,34 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example of a rule that requires ES5 inputs.
+"""
+
+def _es5_consumer(ctx):
+  sources = depset()
+  for d in ctx.attr.deps:
+    if hasattr(d, "typescript"):
+      sources += d.typescript.es5_sources
+
+  return [DefaultInfo(
+      files = sources,
+      runfiles = ctx.runfiles(sources.to_list()),
+  )]
+
+es5_consumer = rule(
+    implementation = _es5_consumer,
+    attrs = {
+        "deps": attr.label_list()
+    }
+)

--- a/examples/es5_output/es5_output_test.sh
+++ b/examples/es5_output/es5_output_test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# should produce named UMD modules
+readonly A_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es5_output/a.js)
+if [[ "$A_JS" != *"define(\"build_bazel_rules_typescript/examples/es5_output/a\","* ]]; then
+  echo "Expected a.js to declare named module, but was"
+  echo "$A_JS"
+  exit 1
+fi
+
+# should give a name to required modules
+readonly B_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es5_output/b.js)
+if [[ "$B_JS" != *"require(\"build_bazel_rules_typescript/examples/es5_output/a\")"* ]]; then
+  echo "Expected b.js to require named module a, but was"
+  echo "$B_JS"
+  exit 1
+fi
+
+# should give a name to required modules from other compilation unit
+if [[ "$A_JS" != *"require(\"build_bazel_rules_typescript/examples/es5_output/rand/rand\")"* ]]; then
+  echo "Expected a.js to require named module c, but was"
+  echo "$A_JS"
+  exit 1
+fi
+
+# should give a name to required generated modules without bazel-bin
+if [[ "$B_JS" != *"require(\"build_bazel_rules_typescript/examples/es5_output/generated\")"* ]]; then
+  echo "Expected b.js to require named module generated, but was"
+  echo "$B_JS"
+  exit 1
+fi

--- a/examples/es5_output/rand/BUILD.bazel
+++ b/examples/es5_output/rand/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//:defs.bzl", "ts_library")
+
+ts_library(
+    name = "rand",
+    srcs = ["rand.ts"],
+    visibility = ["//examples/es5_output:__subpackages__"],
+)

--- a/examples/es5_output/rand/rand.ts
+++ b/examples/es5_output/rand/rand.ts
@@ -1,0 +1,3 @@
+export function rand(): number {
+  return 1; // Well, not that random...
+}

--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -90,6 +90,11 @@ def tsc_wrapped_tsconfig(ctx,
   config["bazelOptions"]["nodeModulesPrefix"] = "node_modules"
   if config["compilerOptions"]["target"] == "es6":
     config["compilerOptions"]["module"] = "es2015"
+  else:
+    # The "typescript.es5_sources" provider is expected to work
+    # in both nodejs and in browsers.
+    # NOTE: tsc-wrapped will always name the enclosed AMD modules
+    config["compilerOptions"]["module"] = "umd"
 
   # If the user gives a tsconfig attribute, the generated file should extend
   # from the user's tsconfig.

--- a/internal/common/tsconfig.bzl
+++ b/internal/common/tsconfig.bzl
@@ -111,8 +111,6 @@ def create_tsconfig(ctx, files, srcs,
       # and builds are faster with the setting on.
       "skipDefaultLibCheck": True,
 
-      # Always produce commonjs modules (might get translated to goog.module).
-      "module": "commonjs",
       "moduleResolution": "node",
 
       "outDir": "/".join([workspace_path, outdir_path]),

--- a/internal/tsc_wrapped/index.ts
+++ b/internal/tsc_wrapped/index.ts
@@ -3,3 +3,4 @@ export * from './compiler_host';
 export * from './file_cache';
 export * from './worker';
 export * from './manifest';
+export * from './umd_module_declaration_transform';

--- a/internal/tsc_wrapped/tsc_wrapped.ts
+++ b/internal/tsc_wrapped/tsc_wrapped.ts
@@ -6,6 +6,7 @@ import {CompilerHost} from './compiler_host';
 import {CachedFileLoader, FileCache, FileLoader, UncachedFileLoader} from './file_cache';
 import {wrap} from './perf_trace';
 import {BazelOptions, parseTsconfig} from './tsconfig';
+import {fixUmdModuleDeclarations} from './umd_module_declaration_transform';
 import {debug, log, runAsWorker, runWorkerLoop} from './worker';
 
 export function main(args) {
@@ -106,7 +107,10 @@ function runOneBuild(
     return false;
   }
   for (const sf of program.getSourceFiles().filter(isCompilationTarget)) {
-    const emitResult = program.emit(sf);
+    const emitResult = program.emit(sf, undefined, undefined, undefined,
+       {after: [
+         fixUmdModuleDeclarations(compilerHost.amdModuleName.bind(compilerHost))
+        ]});
     diagnostics.push(...emitResult.diagnostics);
   }
   if (diagnostics.length > 0) {

--- a/internal/tsc_wrapped/umd_module_declaration_transform.ts
+++ b/internal/tsc_wrapped/umd_module_declaration_transform.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2017 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as ts from 'typescript';
+
+/**
+ * @fileoverview
+ * Workaround for https://github.com/Microsoft/TypeScript/issues/18454
+ * It's fixed at HEAD, so this is needed only until TypeScript 2.6.
+ */
+
+export function fixUmdModuleDeclarations(moduleNamer: (sf: ts.SourceFile) => string):
+    ts.TransformerFactory<ts.SourceFile> {
+  /**
+   * This transformer finds AMD module definitions of the form
+   * define(["require", "exports"], factory);
+   * and inserts the moduleName as a first argument:
+   * define("moduleName", ["require", "exports"], factory);
+   * @param context
+   */
+  return (context: ts.TransformationContext) => (sf: ts.SourceFile):
+                                                    ts.SourceFile => {
+    const visitor = (node: ts.Node): ts.Node => {
+      if (node.kind === ts.SyntaxKind.CallExpression) {
+        const ce = node as ts.CallExpression;
+        if (ce.expression.kind === ts.SyntaxKind.Identifier &&
+            (ce.expression as ts.Identifier).text === 'define' &&
+            ce.arguments.length === 2 &&
+            ce.arguments[1].kind === ts.SyntaxKind.Identifier &&
+            (ce.arguments[1] as ts.Identifier).text === 'factory') {
+          const newArguments = [ts.createLiteral(moduleNamer(sf)), ...ce.arguments];
+          return ts.updateCall(
+              ce, ce.expression, ce.typeArguments, newArguments);
+        }
+      }
+      return ts.visitEachChild(node, visitor, context);
+    };
+    return visitor(sf) as ts.SourceFile;
+  };
+}


### PR DESCRIPTION
This allows faster loading in the browser (no need to transpile commonjs
modules).
We give each module a name (equivalent to the original TS sources using
the `///<amd-module name="some/name"/>` directive) so that they can be
concatenated together when served to the browser.
Also contains a transformer workaround for an upstream UMD bug in
TypeScript, which is only needed until users move to a TS release that
has the fix.

/cc @tbosch @vsavkin