### PR TITLE
Add installation of rules_typescript and tsickle to the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,19 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
 node_repositories(package_json = ["//:package.json"])
 
 
-# Include @bazel/typescript in package.json#devDependencies
 local_repository(
     name = "build_bazel_rules_typescript",
     path = "node_modules/@bazel/typescript",
 )
 ```
 
-We recommend using the Yarn package manager, because it has a built-in command
-to verify the integrity of your `node_modules` directory.
-You can run the version Bazel has already installed:
+This workspace will pull Bazel's [`rules_nodejs`](https://github.com/bazelbuild/rules_nodejs/) from GitHub, but you'll need [`rules_typescript`](https://github.com/bazelbuild/rules_typescript/) and [`tsickle`](https://github.com/angular/tsickle/) installed in your `node_modules` folder.  `rules_nodejs` includes `yarn`.  You can use it to install these dependencies:
 
+```bash
+$ bazel run @yarn//:yarn -- add --dev @bazel/typescript tsickle
+```
+
+As your code evolves and your dependencies change, you'll want to update your local node modules.  You can run Bazel's copy of `yarn` with this command:
 ```sh
 $ bazel run @yarn//:yarn
 ```

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ package(default_visibility = ["//visibility:public"])
 exports_files(["tsconfig.json"])
 
 # NOTE: this will move to node_modules/BUILD in a later release
-filegroup(name = "node_modules", srcs = glob([
-    "node_modules/**/*.js",
-    "node_modules/**/*.d.ts",
-    "node_modules/**/*.json",
-]))
+filegroup(
+    name = "node_modules",
+    srcs = glob([node_modules/**"])
+)
 ```
 
 Next create a `WORKSPACE` file in your project root (or edit the existing one)
@@ -33,13 +32,12 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",
-    tag = "0.0.2", # check for the latest tag when you install
+    tag = "0.1.8", # check for the latest tag when you install
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
 
 node_repositories(package_json = ["//:package.json"])
-
 
 local_repository(
     name = "build_bazel_rules_typescript",

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ package(default_visibility=["//visibility:public"])
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 ts_library(
-    name = "my_code",
-    srcs = glob(["*.ts"]),
+    name = "my-library",
+    srcs = glob(["src/**/*.ts"]),
     deps = ["//path/to/other:library"],
     tsconfig = "//:tsconfig.json",
 )
@@ -79,7 +79,20 @@ ts_library(
 
 Then build it:
 
-`bazel build //path/to/package:target`
+`$ bazel build //path/to/package:target`
+
+> For instance, if you named your `ts_library` "`my-library`" and this `BUILD`
+> file is in `./packages/my-library`, you would run
+>
+> ```
+> $ bazel build packages/my-library:my-library
+> ```
+>
+> If you are already in the `my-library` directory, just omit the package path:
+>
+> ```
+> $ bazel build :my-library
+> ```
 
 The resulting `.d.ts` file paths will be printed. Additionally, the `.js`
 outputs from TypeScript will be written to disk, next to the `.d.ts` files <sup>1</sup>.


### PR DESCRIPTION
Bazel will fail if you don't have `tsickle` and `rules_typescript` as `devDependencies`, so this commit adds instructions to install those.

There's a bigger question here: how come Bazel installs Node + Yarn automatically, but not its other dependencies?  Can we remove the need to manually install `rules_typescript` and `tsickle`?

See also #47.