### PR TITLE
Initial docs site for http://tsetse.info

### DIFF
--- a/docs/check-return-value.md
+++ b/docs/check-return-value.md
@@ -1,0 +1,35 @@
+<!-- FIXME(alexeagle): generate the docs from the sources -->
+
+## The problem
+
+Certain functions do not change the state of the calling object. If these
+functions' return values are unused, then the function call could be removed
+without any effects, indicating a likely bug.
+
+Currently checking the following APIs:
+
+*   `Array.concat()`
+*   `Array.filter()`
+*   `Array.map()`
+*   `Array.slice()`
+*   `Function.bind()`
+*   `Object.create()`
+*   `string.concat()`
+*   `string.normalize()`
+*   `string.padStart()`
+*   `string.padEnd()`
+*   `string.repeat()`
+*   `string.replace()` (Check only if the second parameter is non-function.)
+*   `string.slice()`
+*   `string.split()`
+*   `string.substr()`
+*   `string.substring()`
+*   `string.toLocaleLowerCase()`
+*   `string.toLocaleUpperCase()`
+*   `string.toLowerCase()`
+*   `string.toUpperCase()`
+*   `string.trim()`
+
+For user defined functions, add a `@checkReturnValue` JSDoc to mark functions
+whose return values should be checked. See this
+[example](https://github.com/bazelbuild/rules_typescript/tree/master/internal/tsetse/tests/check_return_value/user_defined_check_return_value.ts).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+# Tsetse
+
+It's common for even the best programmers to make simple mistakes. And sometimes
+a refactoring which seems safe can leave behind code which will never do what's
+intended.
+
+The TypeScript compiler helps prevent a lot of the mistakes you might make when
+writing JavaScript code. However, the set of checks it performs are limited.
+You can augment the static analysis of the compiler by adding linting rules, but
+many toolchains only run the linter when the code is ready for review or submit.
+We want to catch correctness issues in the same way the compiler catches type
+errors.
+
+You can think of the TypeScript compiler as a linter for the Language Spec.
+Tsetse is essentially an extension to that spec, adding new patterns which are
+disallowed in TypeScript programs. The tsetse library lets us plug new
+third-party checks into the standard compiler.
+
+__Tsetse ...__
+
+* __hooks into the standard build process, so all developers run it without configuration__
+* __tells you about mistakes immediately after they're made__
+* __produces suggested fixes, so you can turn on new checks without breaking your build__
+
+Currently, Tsetse is built into the Bazel TypeScript compiler. However we hope
+that it will be possible to plug into the standard `tsc` compiler later.
+
+Tsetse is modelled on the [Error Prone] project for Java.
+
+[Error Prone]: http://errorprone.info
+
+## Example
+
+```javascript
+const s = " Hello, world! ";
+s.trim();
+```
+
+```sh
+$ bazel build :all
+mycode.ts(2,1): error TS21222: return value is unused.
+  See http://tsetse.info/check-return-value
+```


### PR DESCRIPTION
This will be served by GitHub Pages (basically the same setup as errorprone.info)

Docs copied from text I wrote years ago for Error Prone. FYI @cushon