### PR TITLE
Don't push to diagnostics

### DIFF
--- a/internal/tsc_wrapped/strict_deps.ts
+++ b/internal/tsc_wrapped/strict_deps.ts
@@ -51,7 +51,7 @@ export const PLUGIN: pluginApi.Plugin = {
   wrap: (program: ts.Program, config: StrictDepsPluginConfig): ts.Program => {
     const proxy = pluginApi.createProxy(program);
     proxy.getSemanticDiagnostics = function(sourceFile: ts.SourceFile) {
-      const result = program.getSemanticDiagnostics(sourceFile);
+      const result = [...program.getSemanticDiagnostics(sourceFile)];
       perfTrace.wrap('checkModuleDeps', () => {
         result.push(...checkModuleDeps(
             program, config.compilationTargetSrc, config.allowedStrictDeps,


### PR DESCRIPTION
Diagnostics in TS 2.6 are a `ReadonlyArray<Diagnostic>`.

Related to https://github.com/angular/devkit/pull/300
/cc @alexeagle @clydin

