### PR TITLE
update CompilerHost.writeFile to support TS2.6

### DIFF
--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -270,18 +270,18 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
 
   writeFile(
       fileName: string, content: string, writeByteOrderMark: boolean,
-      onError?: (message: string) => void,
-      sourceFiles?: ts.SourceFile[]): void {
+      onError: ((message: string) => void) | undefined,
+      sourceFiles?: ReadonlyArray<ts.SourceFile>): void {
     perfTrace.wrap(
         `writeFile ${fileName}`,
         () => this.writeFileImpl(
-            fileName, content, writeByteOrderMark, onError, sourceFiles));
+            fileName, content, writeByteOrderMark, onError, sourceFiles || []));
   }
 
   writeFileImpl(
       fileName: string, content: string, writeByteOrderMark: boolean,
-      onError?: (message: string) => void,
-      sourceFiles?: ts.SourceFile[]): void {
+      onError: ((message: string) => void) | undefined,
+      sourceFiles: ReadonlyArray<ts.SourceFile>): void {
     // Workaround https://github.com/Microsoft/TypeScript/issues/18648
     if ((this.options.module === ts.ModuleKind.AMD ||
          this.options.module === ts.ModuleKind.UMD) &&


### PR DESCRIPTION
Signature was slightly altered in TS 2.6.  Changes are backwards compatible with TS 2.5.

Related to angular/devkit#300
/cc @alexeagle @filipesilva 