### PR TITLE
allow tsetse to build on TS2.6

### DIFF
--- a/internal/tsetse/runner.ts
+++ b/internal/tsetse/runner.ts
@@ -32,7 +32,7 @@ export const PLUGIN: pluginApi.Plugin = {
 
     const proxy = pluginApi.createProxy(program);
     proxy.getSemanticDiagnostics = (sourceFile: ts.SourceFile) => {
-      const result = program.getSemanticDiagnostics(sourceFile);
+      const result = [...program.getSemanticDiagnostics(sourceFile)];
       perfTrace.wrap('checkConformance', () => {
         result.push(...checker.execute(sourceFile)
                         .map(failure => failure.toDiagnostic()));


### PR DESCRIPTION
Diagnostics in TS 2.6 are a ReadonlyArray<Diagnostic>.

Related to angular/devkit#300
/cc @alexeagle @filipesilva 