### PR TITLE
Allow user to set bazelOptions.disableStrictDeps

### DIFF
--- a/internal/common/tsconfig.bzl
+++ b/internal/common/tsconfig.bzl
@@ -95,11 +95,14 @@ def create_tsconfig(ctx, files, srcs,
       # Explicitly tell the compiler which sources we're interested in (emitting
       # and type checking).
       "compilationTargetSrc": [s.path for s in srcs],
-      "disableStrictDeps": disable_strict_deps,
-      "allowedStrictDeps": [f.path for f in allowed_deps],
       "addDtsClutzAliases": getattr(ctx.attr, "add_dts_clutz_aliases", False),
       "expectedDiagnostics": getattr(ctx.attr, "expected_diagnostics", []),
   }
+
+  if disable_strict_deps:
+    bazel_options["disableStrictDeps"] = disable_strict_deps
+  else:
+    bazel_options["allowedStrictDeps"] = [f.path for f in allowed_deps]
 
   # Keep these options in sync with those in playground/playground.ts.
   compiler_options = {

--- a/internal/tsc_wrapped/BUILD.bazel
+++ b/internal/tsc_wrapped/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//:defs.bzl", "ts_library")
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "jasmine_node_test")
 
 # Vanilla typescript compiler: run the tsc.js binary distributed by TypeScript
 nodejs_binary(
@@ -44,6 +44,11 @@ ts_library(
     supports_workers = False,
     tsconfig = ":tsconfig.json",
     visibility = ["//visibility:public"],
+    data = [ 
+        # Should be @bazel_tools//src/main/protobuf:worker_protocol.proto
+        # see https://github.com/bazelbuild/bazel/issues/3155#issuecomment-308156976
+        "//internal:worker_protocol.proto",
+    ],
     deps = [
         ":perf_trace",
         ":plugin_api",
@@ -74,12 +79,21 @@ nodejs_binary(
     data = [
         ":tsc_wrapped",
         "@//:node_modules",
-
-        # Should be @bazel_tools//src/main/protobuf:worker_protocol.proto
-        # see https://github.com/bazelbuild/bazel/issues/3155#issuecomment-308156976
-        "//internal:worker_protocol.proto",
     ],
     entry_point = "build_bazel_rules_typescript/internal/tsc_wrapped/tsc_wrapped.js",
     templated_args = ["--node_options=--expose-gc"],
     visibility = ["//visibility:public"],
+)
+
+ts_library(
+    name = "test_lib",
+    srcs = glob(["*_test.ts"]) + ["test_support.ts"],
+    deps = [":tsc_wrapped"],
+    tsconfig = ":tsconfig.json",
+)
+
+jasmine_node_test(
+    name = "test",
+    srcs = [],
+    deps = [":test_lib"],
 )

--- a/internal/tsc_wrapped/strict_deps_test.ts
+++ b/internal/tsc_wrapped/strict_deps_test.ts
@@ -27,7 +27,6 @@ describe('strict deps', () => {
       baseUrl: '/src',
       rootDirs: ['/src', '/src/blaze-bin'],
       paths: {'*': ['*', 'blaze-bin/*']},
-      traceResolution: true
     };
 
     // Fake compiler host relying on `files` above.

--- a/internal/tsc_wrapped/tsconfig.json
+++ b/internal/tsc_wrapped/tsconfig.json
@@ -3,7 +3,8 @@
     "strict": true,
     "types": [
       "node",
-      "source-map"
+      "source-map",
+      "jasmine"
     ],
     "lib": [
       "dom",

--- a/internal/tsc_wrapped/tsconfig_test.ts
+++ b/internal/tsc_wrapped/tsconfig_test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2017 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as path from 'path';
+import * as ts from 'typescript';
+
+import {parseTsconfig} from './tsconfig';
+
+describe('tsconfig', () => {
+  it('honors bazelOptions in the users tsconfig', () => {
+    const userTsconfig = {
+      bazelOptions: {disableStrictDeps: true},
+    };
+    const generatedTsconfig = {
+      extends: './user.tsconfig',
+      files: ['a.ts'],
+      bazelOptions: {},
+    };
+    const files = {
+      [path.resolve('path/to/user.tsconfig.json')]: '/*some comment*/\n' + JSON.stringify(userTsconfig),
+      [path.resolve('path/to/generated.tsconfig.json')]: JSON.stringify(generatedTsconfig),
+    };
+    const host: ts.ParseConfigHost = {
+      useCaseSensitiveFileNames: true,
+      fileExists: (path: string) => !!files[path],
+      readFile: (path: string) => files[path],
+      readDirectory(
+          rootDir: string, extensions: ReadonlyArray<string>, excludes: ReadonlyArray<string>,
+          includes: ReadonlyArray<string>, depth: number): string[] {
+        throw new Error(`unexpected readDirectory of ${rootDir}`);
+      },
+    };
+
+    const [parsed, diagnostics, {target}] = parseTsconfig('path/to/generated.tsconfig.json', host);
+    expect(diagnostics).toBeNull();
+    if (!parsed) {
+      fail('Expected parsed');
+    } else {
+      const {options, bazelOpts, files, config} = parsed;
+      expect(bazelOpts.disableStrictDeps).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
At Google, all code is required to be strict-deps compliant, except third-party code outside our control.
Users may have a similar need to opt-out some of their code, or might decide not to use this feature on
first-party code either.

Also in this commit:
- Add missing unit test for tsconfig.ts
- Include the source-map-support library so node stack traces can have .ts paths
  (also requires a change in rules_nodejs)
- Update clang-format, should (mostly?) match google-internal style
- Add --config=debug options for debugging node programs

See #89 