### PR TITLE
Add skipLibCheck to default tsconfig

### DIFF
--- a/internal/common/tsconfig.bzl
+++ b/internal/common/tsconfig.bzl
@@ -108,10 +108,10 @@ def create_tsconfig(ctx, files, srcs,
       # Has no effect in closure/ES2015 mode. Always true just for simplicity.
       "downlevelIteration": True,
 
-      # Do not type-check the lib.*.d.ts.
+      # Do not type-check the *.d.ts.
       # We think this shouldn't be necessary but haven't figured out why yet
       # and builds are faster with the setting on.
-      "skipDefaultLibCheck": True,
+      "skipLibCheck": True,
 
       "moduleResolution": "node",
 

--- a/internal/e2e/errorchecks/erroneous.ts
+++ b/internal/e2e/errorchecks/erroneous.ts
@@ -1,1 +1,2 @@
 export const x: number = 'not a number';
+const y: TypeThatDoesNotExist = null;

--- a/internal/e2e/errorchecks/erroneous_decl.d.ts
+++ b/internal/e2e/errorchecks/erroneous_decl.d.ts
@@ -1,2 +1,0 @@
-
-export declare class Foo { field: TypeThatDoesNotExist; }


### PR DESCRIPTION
Fixes #92.
Also, `skipDefaultLibCheck` just above is deprecated, and should be replaced with `skipLibCheck`.