### PR TITLE
Move our deps to devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ local_repository(
     name = "build_bazel_rules_typescript",
     path = "node_modules/@bazel/typescript",
 )
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_repositories")
+
+ts_repositories()
 ```
 
 We recommend using the Yarn package manager, because it has a built-in command

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,10 +17,10 @@ workspace(name = "build_bazel_rules_typescript")
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs",
-    tag = "0.2.2",
+    commit = "6b498e3",
 )
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "npm_install")
 
 # Install a hermetic version of node.
 # After this is run, these labels will be available:
@@ -30,6 +30,10 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
 # - The yarn package manager:
 #   @yarn//:yarn
 node_repositories(package_json = ["//:package.json"])
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_repositories")
+
+ts_repositories()
 
 http_archive(
     name = "io_bazel_rules_go",

--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -167,3 +167,11 @@ ts_library = rule(
         "tsconfig": "%{name}_tsconfig.json"
     }
 )
+
+# Helper that compiles typescript libraries using the vanilla tsc compiler
+def tsc_library(**kwargs):
+  ts_library(
+      supports_workers = False,
+      compiler = "//internal/tsc_wrapped:tsc",
+      node_modules = "@build_bazel_rules_typescript_deps//:node_modules",
+      **kwargs)

--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -36,7 +36,7 @@ def _compile_action(ctx, inputs, outputs, config_file_path):
   for externs_file in externs_files:
     ctx.file_action(output=externs_file, content="")
 
-  action_inputs = inputs + [f for f in ctx.files.node_modules
+  action_inputs = inputs + [f for f in ctx.files.node_modules + ctx.files._tsc_wrapped_deps
                             if f.path.endswith(".ts") or f.path.endswith(".json")]
   if ctx.file.tsconfig:
     action_inputs += [ctx.file.tsconfig]
@@ -158,6 +158,7 @@ ts_library = rule(
                 executable=True,
                 cfg="host"),
         "supports_workers": attr.bool(default = True),
+        "_tsc_wrapped_deps": attr.label(default = Label("@build_bazel_rules_typescript_deps//:node_modules")),
         # @// is special syntax for the "main" repository
         # The default assumes the user specified a target "node_modules" in their
         # root BUILD file.

--- a/internal/common/tsconfig.bzl
+++ b/internal/common/tsconfig.bzl
@@ -62,8 +62,17 @@ def create_tsconfig(ctx, files, srcs,
         ctx.configuration.genfiles_dir.path,
         ctx.configuration.bin_dir.path
     ]]
+
+    node_modules_mappings = []
+    if (hasattr(ctx.attr, "node_modules")):
+      node_modules_mappings.append("/".join([p for p in [
+          ctx.attr.node_modules.label.workspace_root,
+          ctx.attr.node_modules.label.package,
+          "node_modules",
+          "*"] if p]))
+
     module_roots = {
-        "*": base_path_mappings,
+        "*": base_path_mappings + node_modules_mappings,
         ctx.workspace_name + "/*": base_path_mappings,
     }
   module_mappings = get_module_mappings(ctx.label, ctx.attr, srcs = srcs)
@@ -171,6 +180,14 @@ def create_tsconfig(ctx, files, srcs,
       # Implied by inlineSourceMap: True
       "sourceMap": False,
   }
+
+  if hasattr(ctx.attr, "node_modules"):
+    compiler_options["typeRoots"] = ["/".join([p for p in [
+        workspace_path,
+        ctx.attr.node_modules.label.workspace_root,
+        ctx.attr.node_modules.label.package,
+        "node_modules",
+        "@types"] if p])]
 
   if _DEBUG:
     compiler_options["traceResolution"] = True

--- a/internal/ts_repositories.bzl
+++ b/internal/ts_repositories.bzl
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Public API surface is re-exported here.
-
-Users should not load files under "/internal"
+"""The ts_repositories rule installs build-time dependencies.
 """
-load("//internal:build_defs.bzl", _ts_library = "ts_library")
-load("//internal:ts_config.bzl", _ts_config = "ts_config")
-load("//internal:ts_repositories.bzl", _ts_repositories = "ts_repositories")
-load("//internal/devserver:ts_devserver.bzl", _ts_devserver = "ts_devserver_macro")
 
-ts_library = _ts_library
-ts_config = _ts_config
-ts_repositories = _ts_repositories
-ts_devserver = _ts_devserver
+load("@build_bazel_rules_nodejs//:defs.bzl", "npm_install")
+
+def ts_repositories():
+  npm_install(
+      name = "build_bazel_rules_typescript_deps",
+      package_json = "@build_bazel_rules_typescript//:package.json",
+  )

--- a/internal/tsc_wrapped/BUILD.bazel
+++ b/internal/tsc_wrapped/BUILD.bazel
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:defs.bzl", "ts_library")
+
+load("//internal:build_defs.bzl", ts_library = "tsc_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "jasmine_node_test")
 
 # Vanilla typescript compiler: run the tsc.js binary distributed by TypeScript
 nodejs_binary(
     name = "tsc",
-    data = ["@//:node_modules"],
+    node_modules = "@build_bazel_rules_typescript_deps//:node_modules",
     entry_point = "typescript/lib/tsc.js",
     visibility = ["//internal:__subpackages__"],
 )
@@ -38,13 +39,11 @@ ts_library(
         "umd_module_declaration_transform.ts",
         "worker.ts",
     ],
-    compiler = ":tsc",
     module_name = "@bazel/typescript",
     module_root = "index.d.ts",
-    supports_workers = False,
     tsconfig = ":tsconfig.json",
     visibility = ["//visibility:public"],
-    data = [ 
+    data = [
         # Should be @bazel_tools//src/main/protobuf:worker_protocol.proto
         # see https://github.com/bazelbuild/bazel/issues/3155#issuecomment-308156976
         "//internal:worker_protocol.proto",
@@ -59,16 +58,12 @@ ts_library(
 ts_library(
     name = "plugin_api",
     srcs = ["plugin_api.ts"],
-    compiler = ":tsc",
-    supports_workers = False,
     visibility = ["//internal/tsetse:__pkg__"],
 )
 
 ts_library(
     name = "perf_trace",
     srcs = ["perf_trace.ts"],
-    compiler = ":tsc",
-    supports_workers = False,
     visibility = ["//internal/tsetse:__pkg__"],
 )
 
@@ -78,8 +73,12 @@ nodejs_binary(
     name = "tsc_wrapped_bin",
     data = [
         ":tsc_wrapped",
-        "@//:node_modules",
+
+        # Should be @bazel_tools//src/main/protobuf:worker_protocol.proto
+        # see https://github.com/bazelbuild/bazel/issues/3155#issuecomment-308156976
+        "//internal:worker_protocol.proto",
     ],
+    node_modules = "@build_bazel_rules_typescript_deps//:node_modules",
     entry_point = "build_bazel_rules_typescript/internal/tsc_wrapped/tsc_wrapped.js",
     templated_args = ["--node_options=--expose-gc"],
     visibility = ["//visibility:public"],

--- a/internal/tsetse/BUILD.bazel
+++ b/internal/tsetse/BUILD.bazel
@@ -5,7 +5,7 @@ package(default_visibility = [
 
 licenses(["notice"])  # Apache 2.0
 
-load("//:defs.bzl", "ts_library")
+load("//internal:build_defs.bzl", ts_library = "tsc_library")
 
 ts_library(
     name = "tsetse_lib",
@@ -15,8 +15,6 @@ ts_library(
         "failure.ts",
         "rule.ts",
     ],
-    compiler = "//internal/tsc_wrapped:tsc",
-    supports_workers = False,
     tsconfig = ":tsconfig.json",
 )
 
@@ -25,8 +23,6 @@ ts_library(
     srcs = [
         "runner.ts",
     ],
-    compiler = "//internal/tsc_wrapped:tsc",
-    supports_workers = False,
     deps = [
         ":tsetse_lib",
         "//internal/tsc_wrapped:perf_trace",
@@ -40,8 +36,6 @@ ts_library(
     srcs = [
         "language_service_plugin.ts",
     ],
-    compiler = "//internal/tsc_wrapped:tsc",
-    supports_workers = False,
     deps = [
         ":runner",
         ":tsetse_lib",

--- a/internal/tsetse/rules/BUILD
+++ b/internal/tsetse/rules/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache 2.0
 
-load("//:defs.bzl", "ts_library")
+load("//internal:build_defs.bzl", ts_library = "tsc_library")
 
 ts_library(
     name = "rules",
@@ -22,8 +22,6 @@ ts_library(
         "check_return_value_rule.ts",
         "equals_nan_rule.ts",
     ],
-    compiler = "//internal/tsc_wrapped:tsc",
-    supports_workers = False,
     tsconfig = "//internal/tsetse:tsconfig.json",
     visibility = ["//internal/tsetse:__pkg__"],
     deps = [

--- a/package.json
+++ b/package.json
@@ -1,23 +1,27 @@
 {
     "name": "@bazel/typescript",
     "description": "Build TypeScript with Bazel",
-    "version": "0.5.0",
-    "keywords": ["typescript", "bazel"],
+    "version": "0.6.0",
+    "keywords": [
+        "typescript",
+        "bazel"
+    ],
     "homepage": "https://github.com/bazelbuild/rules_typescript",
     "license": "Apache-2.0",
-    "dependencies": {
+    "peerDependencies": {
+        "typescript": ">=2.4.2"
+    },
+    "devDependencies": {
+        "@types/jasmine": "^2.8.2",
         "@types/node": "7.0.18",
         "@types/source-map": "^0.5.1",
+        "clang-format": "1.0.49",
+        "concurrently": "^3.5.1",
+        "protractor": "^5.2.0",
         "protobufjs": "5.0.0",
         "tsickle": "0.25.x",
         "typescript": "2.5.x",
         "tsutils": "2.12.1"
-    },
-    "devDependencies": {
-        "@types/jasmine": "^2.8.2",
-        "clang-format": "1.0.49",
-        "concurrently": "^3.5.1",
-        "protractor": "^5.2.0"
     },
     "scripts": {
         "pretest": "webdriver-manager update && bazel build examples/app:all",


### PR DESCRIPTION
This is a significant change. Instead of relying on the user to install @bazel/typescript and get
our dependencies installed in their node_modules directory, we install our own hermetic node_modules
in an external workspace using the new npm_install rule introduced in
https://github.com/bazelbuild/rules_nodejs/pull/67

Fixes #88
Fixes #64

This also means we use our own TypeScript compiler to compile
tsc_wrapped. Users are free to use any later TypeScript version to
compile their own code.

Fixes #48

BREAKING CHANGE:

Users now need to load and run the ts_repositories() repository rule.