### PR TITLE
Add example showing how to compile an angularjs project

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,3 +46,29 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 go_rules_dependencies()
 
 go_register_toolchains()
+
+git_repository(
+    name = "io_bazel_rules_closure",
+    commit = "172f84fe96e07214fa7337b081648d4a61b45b93",
+    remote = "https://github.com/bazelbuild/rules_closure",
+)
+
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
+
+closure_repositories()
+
+git_repository(
+    name = "angular",
+    commit = "d7f4f50f1346e23b7b11407fdc775b06e55a7bfd",
+    remote = "https://github.com/angular/bazel-builds.git",
+)
+
+git_repository(
+    name = "io_bazel_rules_sass",
+    remote = "https://github.com/bazelbuild/rules_sass.git",
+    tag = "0.0.3",
+)
+
+load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")
+
+sass_repositories()

--- a/examples/angularjs/BUILD.bazel
+++ b/examples/angularjs/BUILD.bazel
@@ -1,0 +1,96 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver", "ts_library")
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_binary", "closure_js_library")
+load(":internal_node_module.bzl", "internal_node_module")
+load(":closure_ts_binary.bzl", "closure_ts_binary")
+
+
+filegroup(
+    name = "node_modules",
+    # Only include files needed for type-checking and runtime
+    srcs = glob([
+        "node_modules/**/*.js",
+        "node_modules/**/*.d.ts",
+        "node_modules/**/*.json"
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+ts_library(
+    name = "ts_library",
+    srcs = ["main.ts"],
+    deps = ["//examples/angularjs/hello-world"],
+    node_modules = "//examples/angularjs:node_modules",
+)
+
+STATIC_FILES = [
+    "index.html",
+    "node_modules/angular/angular.js",
+    "//examples/angularjs/hello-world:static-files",
+]
+
+# Create a live-reload enable development server:
+#
+# npm run devserver
+# ibazel run //examples/angular:devserver
+ts_devserver(
+    name = "devserver",
+    serving_path = "/bundle.js",
+    static_files = STATIC_FILES,
+    deps = [":ts_library"],
+)
+
+# We do not want closure to compile angular.js, and instead will serve angular.min.js.
+# Serving this file makes angular availible on the window as a global variable.
+# @types/angular defines angularjs as a commonJS module with an import path of 'angular'
+# The shim exports the global variable to make it importable from the import path.
+internal_node_module(
+    name = "angularjs_shim",
+    import_path = "angular",
+    main = "angularjs_shim.js",
+)
+
+closure_js_library(
+    name = "angularjs_externs",
+    srcs = ["node_modules/google-closure-compiler/contrib/externs/angular-1.6.js"],
+)
+
+# Create a closure minified production bundle.
+closure_ts_binary(
+    name = "bundle",
+    defs = [
+        "--jscomp_off=checkTypes",
+        # Needed to process the shim's commonJS module.
+        "--process_common_js_modules",
+    ],
+    deps = [
+        ":angularjs_externs",
+        ":angularjs_shim",
+        ":ts_library",
+    ],
+)
+
+# Create a production server to serve tbe bundle.
+#
+# npm run prodserver
+# ibazel run //examples/angular:devserver
+ts_devserver(
+    name = "prodserver",
+    # :bundle.js produced by closure_ts_binary
+    static_files = STATIC_FILES + [":bundle.js"],
+)

--- a/examples/angularjs/angularjs_shim.js
+++ b/examples/angularjs/angularjs_shim.js
@@ -1,0 +1,1 @@
+module.exports = angular;

--- a/examples/angularjs/closure_ts_binary.bzl
+++ b/examples/angularjs/closure_ts_binary.bzl
@@ -1,0 +1,59 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Renames outputted .closure.js files to be .js files so that ES6
+module loading can work properly using the closure_js_binary rule
+from rules_closure.
+"""
+
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_binary")    
+
+def _reroot_closure_files_impl(ctx):
+  rerooted_es6_srcs = depset()
+
+  for dep in ctx.attr.deps:
+    if hasattr(dep, "typescript"):
+      for es6_src in dep.typescript.transitive_es6_srcs:
+        rerooted_es6_src = ctx.actions.declare_file(
+          "%s/%s" % (
+            es6_src.dirname, 
+            es6_src.basename.replace(".closure", "")))
+        ctx.actions.expand_template(
+          output = rerooted_es6_src,
+          template = es6_src,
+          substitutions = {}
+        )
+        rerooted_es6_srcs += [rerooted_es6_src]
+    elif hasattr(dep, "closure_js_library"):
+      rerooted_es6_srcs += dep.closure_js_library.srcs
+    else:
+      fail(
+          ("%s is neither a TypeScript nor a Closure JS library producing rule." % dep.label) +
+          "\nDependencies must be ts_library, ts_declaration, or closure_js_library.")
+    
+  return struct(closure_js_library = struct(srcs = rerooted_es6_srcs))
+
+
+_reroot_closure_files = rule(
+    attrs = {"deps": attr.label_list(mandatory = True)},
+    implementation = _reroot_closure_files_impl,
+)
+
+
+def closure_ts_binary(name, deps, **kwargs):
+    rerooted_name = name + "_reroot_closure_files"
+
+    _reroot_closure_files(name = rerooted_name, deps = deps)
+
+    closure_js_binary(name = name, deps = [":" + rerooted_name], **kwargs)

--- a/examples/angularjs/hello-world/BUILD.bazel
+++ b/examples/angularjs/hello-world/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "hello-world",
+    srcs = ["hello-world.ts"],
+    node_modules = "//examples/angularjs:node_modules",
+)
+
+filegroup(
+    name = "static-files",
+    srcs = [
+        "hello-world.css",
+        "hello-world.html",
+    ],
+)

--- a/examples/angularjs/hello-world/hello-world.css
+++ b/examples/angularjs/hello-world/hello-world.css
@@ -1,0 +1,7 @@
+@import url('https://fonts.googleapis.com/css?family=Spectral+SC');
+
+h1 {
+    font-family: 'Spectral SC', serif;
+    font-size: 24px;
+    color: forestgreen;
+}

--- a/examples/angularjs/hello-world/hello-world.html
+++ b/examples/angularjs/hello-world/hello-world.html
@@ -1,0 +1,3 @@
+<h1 class="animated fadeInRightBig">
+    Hello {{ ctrl.world }}
+</h1>

--- a/examples/angularjs/hello-world/hello-world.ts
+++ b/examples/angularjs/hello-world/hello-world.ts
@@ -1,0 +1,16 @@
+import {IComponentOptions} from 'angular';
+
+export class HelloWorldController {
+  world: string;
+
+  constructor() {
+    this['world'] = '';
+  }
+}
+
+export const helloWorldComponent: IComponentOptions = {
+  templateUrl: '/hello-world/hello-world.html',
+  controller: HelloWorldController,
+  controllerAs: 'ctrl',
+  bindings: {'world': '@'},
+}

--- a/examples/angularjs/index.html
+++ b/examples/angularjs/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html ng-app="HelloWorldApp">
+  <head>
+    <title>ts_devserver example</title>
+    <link rel="stylesheet" type="text/css" href="/hello-world/hello-world.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@3.5.2/animate.min.css">
+    
+    <script src="/node_modules/angular/angular.js"></script>
+    <script src="/bundle.js"></script>
+  </head>
+  <body>
+    <hello-world world="world"></hello-world>
+  </body>
+</html>

--- a/examples/angularjs/internal_node_module.bzl
+++ b/examples/angularjs/internal_node_module.bzl
@@ -1,0 +1,48 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Create an internal node module that can be included in the deps for other
+rules and that can be required as require('module_name').
+"""
+
+def _internal_node_module(ctx):
+  module_path = 'node_modules/%s' % ctx.attr.import_path
+
+  package_json = ctx.new_file("%s/package.json" % module_path)
+  ctx.file_action(package_json, '{"main": "index.js"}')
+
+  main_file = ctx.actions.declare_file("%s/index.js" % module_path)
+  ctx.actions.expand_template(
+    output = main_file,
+    template = ctx.file.main,
+    substitutions = {}
+  )
+
+  return struct(
+      files = depset([package_json, main_file]),
+      closure_js_library = struct(
+          srcs = [package_json, main_file],
+      )
+  )
+
+internal_node_module = rule(
+    attrs = {
+        "main": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "import_path": attr.string(mandatory = True),
+    },
+    implementation = _internal_node_module,
+)

--- a/examples/angularjs/main.ts
+++ b/examples/angularjs/main.ts
@@ -1,0 +1,4 @@
+import * as ng from 'angular';
+import {helloWorldComponent} from './hello-world/hello-world';
+
+ng.module('HelloWorldApp', []).component('helloWorld', helloWorldComponent);

--- a/examples/angularjs/package-lock.json
+++ b/examples/angularjs/package-lock.json
@@ -1,0 +1,242 @@
+{
+  "name": "angularjs-example",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@bazel/ibazel": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@bazel/ibazel/-/ibazel-0.1.1.tgz",
+      "integrity": "sha1-+XDAi05O+wqxfgSt48xhBVTzO+0=",
+      "dev": true
+    },
+    "@types/angular": {
+      "version": "1.6.39",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.39.tgz",
+      "integrity": "sha512-fRj26foAwYbjOwnGSpIaY05+jRxZevHWwzcSrQIsJgh5Xrosbu4fX99+obJH4YFFS8+EkYRwsSpf2vpVddSNVw==",
+      "dev": true
+    },
+    "angular": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.7.tgz",
+      "integrity": "sha1-D4mDfa4XdrAcyx+iCW2w2Tc9mJc="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "dev": true
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "process-nextick-args": "1.0.7",
+        "through2": "2.0.3"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "google-closure-compiler": {
+      "version": "20171112.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20171112.0.0.tgz",
+      "integrity": "sha1-eHENtO+J/1QGOdgA5tWffLfPLZg=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "vinyl": "2.1.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "typescript": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "vinyl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+      "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+      "dev": true,
+      "requires": {
+        "clone": "2.1.1",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.0.0",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    }
+  }
+}

--- a/examples/angularjs/package.json
+++ b/examples/angularjs/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "angularjs-example",
+  "version": "0.0.1",
+  "description": "An example of how to bundle an angularjs app with rules_closure",
+  "main": "index.ts",
+  "scripts": {
+    "devserver": "ibazel run //examples/angularjs:devserver",
+    "prodserver": "ibazel run //examples/angularjs:prodserver"
+  },
+  "author": "The Bazel Authors",
+  "license": "Apache License, Version 2.0",
+  "dependencies": {
+    "angular": "^1.6.7",
+    "typescript": "^2.6.2"
+  },
+  "devDependencies": {
+    "@bazel/ibazel": "^0.1.1",
+    "@types/angular": "^1.6.39",
+    "google-closure-compiler": "^20171112.0.0"
+  }
+}

--- a/examples/closure_compiled/BUILD.bazel
+++ b/examples/closure_compiled/BUILD.bazel
@@ -1,0 +1,41 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_binary")
+load("//examples/angularjs:closure_ts_binary.bzl", "closure_ts_binary")
+load("//:defs.bzl", "ts_library")
+
+ts_library(
+    name = "child",
+    srcs = [
+        "greeter.ts",
+        "declarations.d.ts",
+    ],
+)
+
+ts_library(
+    name = "parent",
+    srcs = ["main.ts"],
+    deps = [":child"],
+)
+
+closure_ts_binary(
+    name = "closure_compiled",
+    deps = [":parent"],
+    defs = [
+        "--jscomp_off=checkTypes",
+    ],
+)

--- a/examples/closure_compiled/declarations.d.ts
+++ b/examples/closure_compiled/declarations.d.ts
@@ -1,0 +1,3 @@
+declare function someDeclaredFunction(s: string): string;
+
+declare const someDeclaredString: string;

--- a/examples/closure_compiled/greeter.ts
+++ b/examples/closure_compiled/greeter.ts
@@ -1,0 +1,6 @@
+export class Greeter {
+  private greeting = 'hello, world' + someDeclaredFunction(someDeclaredString);
+  greet() {
+    return this.greeting;
+  }
+}

--- a/examples/closure_compiled/main.ts
+++ b/examples/closure_compiled/main.ts
@@ -1,0 +1,3 @@
+import {Greeter} from './greeter';
+
+console.log(new Greeter().greet());

--- a/internal/common/compilation.bzl
+++ b/internal/common/compilation.bzl
@@ -33,7 +33,7 @@ COMMON_ATTRIBUTES = dict(BASE_ATTRIBUTES, **{
         cfg = "data",
     ),
     # TODO(evanm): make this the default and remove the option.
-    "runtime": attr.string(default="browser"),
+    "runtime": attr.string(default = "browser"),
     # Used to determine module mappings
     "module_name": attr.string(),
     "module_root": attr.string(),
@@ -53,12 +53,11 @@ COMMON_ATTRIBUTES = dict(BASE_ATTRIBUTES, **{
     # "diagnostic:regexp", e.g. "TS1234:failed to quizzle the .* wobble".
     # Useful to test for expected compilation errors.
     "expected_diagnostics": attr.string_list(),
-
 })
 
 COMMON_OUTPUTS = {
     # Allow the tsconfig.json to be generated without running compile actions.
-    "tsconfig": "%{name}_tsconfig.json"
+    "tsconfig": "%{name}_tsconfig.json",
 }
 
 # TODO(plf): Enforce this at analysis time.
@@ -122,7 +121,6 @@ def _outputs(ctx, label):
     devmode_js = devmode_js_files,
     declarations = declaration_files,
   )
-
 
 def compile_ts(ctx,
                is_library,
@@ -292,6 +290,27 @@ def compile_ts(ctx,
   if not is_library:
     files += depset(tsickle_externs)
 
+  rerooted_es6_sources = []
+  es6_js_modules_roots = []
+
+  for source in es6_sources:
+    root = source.dirname
+    es6_js_modules_roots.append(root)
+
+    file_path = "%s/%s" % (root, source.basename.replace(".closure", ""))
+    rooted_file = ctx.actions.declare_file(file_path)
+
+    ctx.actions.expand_template(
+        output = rooted_file,
+        template = source,
+        substitutions = {}
+    )
+    rerooted_es6_sources.append(rooted_file)
+
+  transitive_es6_srcs = depset()
+  for dep in ctx.attr.deps:
+    transitive_es6_srcs += getattr(dep.typescript, "transitive_es6_srcs", [])
+
   return {
       "files": files,
       "runfiles": ctx.runfiles(
@@ -311,6 +330,7 @@ def compile_ts(ctx,
           "type_blacklisted_declarations": type_blacklisted_declarations,
           "tsickle_externs": tsickle_externs,
           "replay_params": replay_params,
+          "transitive_es6_srcs": transitive_es6_srcs + es6_sources,
       },
       # Expose the tags so that a Skylark aspect can access them.
       "tags": ctx.attr.tags,

--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -130,8 +130,8 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
 
   /** Allows suppressing warnings for specific known libraries */
   shouldIgnoreWarningsForPath(filePath: string): boolean {
-    return this.bazelOpts.ignoreWarningPaths.some(
-        p => !!filePath.match(new RegExp(p)));
+    return (this.bazelOpts.ignoreWarningPaths || [])
+        .some(p => !!filePath.match(new RegExp(p)));
   }
 
   fileNameToModuleId(fileName: string): string {
@@ -289,7 +289,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
 
   writeFile(
       fileName: string, content: string, writeByteOrderMark: boolean,
-      onError: ((message: string) => void) | undefined,
+      onError: ((message: string) => void)|undefined,
       sourceFiles: ReadonlyArray<ts.SourceFile>): void {
     perfTrace.wrap(
         `writeFile ${fileName}`,
@@ -299,7 +299,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
 
   writeFileImpl(
       fileName: string, content: string, writeByteOrderMark: boolean,
-      onError: ((message: string) => void) | undefined,
+      onError: ((message: string) => void)|undefined,
       sourceFiles: ReadonlyArray<ts.SourceFile>): void {
     // Workaround https://github.com/Microsoft/TypeScript/issues/18648
     if ((this.options.module === ts.ModuleKind.AMD ||

--- a/internal/tsc_wrapped/tsc_wrapped.ts
+++ b/internal/tsc_wrapped/tsc_wrapped.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as tsickle from 'tsickle';
 import * as ts from 'typescript';
 
 import {PLUGIN as tsetsePlugin} from '../tsetse/runner';
@@ -93,7 +94,7 @@ function runOneBuild(
   }
   let diags: ts.Diagnostic[] = [];
   // Install extra diagnostic plugins
-  if (!bazelOpts.disableStrictDeps) {
+  if (!bazelOpts.disableStrictDeps && !bazelOpts.nodeModulesPrefix) {
     const ignoredFilesPrefixes = [bazelOpts.nodeModulesPrefix];
     if (options.rootDir) {
       // compilerHost.realpath does not work inside of the bazel-sandbox in some
@@ -143,6 +144,25 @@ function runOneBuild(
   if (diags.length > 0) {
     console.error(diagnostics.format(bazelOpts.target, diags));
     return false;
+  }
+
+  const emitResults: tsickle.EmitResult[] =
+      program.getSourceFiles()
+          .filter(isCompilationTarget)
+          .map(
+              file => tsickle.emitWithTsickle(
+                  program, compilerHost, (compilerHost as ts.CompilerHost),
+                  options, file));
+
+  const emitResult = tsickle.mergeEmitResults(emitResults);
+
+  let externs = '/** @externs */';
+  if (bazelOpts.tsickleGenerateExterns) {
+    externs += tsickle.getGeneratedExterns(emitResult.externs);
+  }
+
+  if (bazelOpts.tsickleExternsPath) {
+    fs.writeFileSync(bazelOpts.tsickleExternsPath, externs);
   }
 
   for (const sf of program.getSourceFiles().filter(isCompilationTarget)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1916 @@
+{
+    "name": "@bazel/typescript",
+    "version": "0.5.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@angular/compiler": {
+            "version": "git+https://github.com/angular/compiler-builds.git#19b350049d1ead215880d0fe3b3fe89f7baa03b1",
+            "requires": {
+                "tslib": "1.8.0"
+            }
+        },
+        "@angular/compiler-cli": {
+            "version": "git+https://github.com/angular/compiler-cli-builds.git#b4d97b8e978c6e9b3007e5ed369be4da50f3900f",
+            "requires": {
+                "chokidar": "1.7.0",
+                "minimist": "1.2.0",
+                "reflect-metadata": "0.1.10",
+                "tsickle": "0.25.5"
+            }
+        },
+        "@angular/core": {
+            "version": "git+https://github.com/angular/core-builds.git#5756a3175471eb5b36657091d41cb387b1117706",
+            "requires": {
+                "tslib": "1.8.0"
+            }
+        },
+        "@angular/platform-browser": {
+            "version": "git+https://github.com/angular/platform-browser-builds.git#9bccadc975a60c26fe7e6c494380ac7cc4529083",
+            "requires": {
+                "tslib": "1.8.0"
+            }
+        },
+        "@types/jasmine": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.2.tgz",
+            "integrity": "sha512-RabEJPjYMpjWqW1qYj4k0rlgP5uzyguoc0yxedJdq7t5h19MYvqhjCR1evM3raZ/peHRxp1Qfl24iawvkibSug==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "7.0.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.18.tgz",
+            "integrity": "sha1-zWfyfT3Az7dG8L3V4IbExdVb4XM="
+        },
+        "@types/q": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+            "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
+            "dev": true
+        },
+        "@types/selenium-webdriver": {
+            "version": "2.53.43",
+            "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz",
+            "integrity": "sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==",
+            "dev": true
+        },
+        "@types/source-map": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz",
+            "integrity": "sha512-++w4WmMbk3dS3UeHGzAG+xJOSz5Xqtjys/TBkqG3qp3SeWE7Wwezqe5eB7B51cxUyh4PW7bwVotpsLdBK0D8cw=="
+        },
+        "adm-zip": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
+            "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+            "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+            "dev": true,
+            "requires": {
+                "extend": "3.0.1",
+                "semver": "5.0.3"
+            }
+        },
+        "ajv": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+            "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+            "dev": true
+        },
+        "anymatch": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+            "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+            "requires": {
+                "micromatch": "2.3.11",
+                "normalize-path": "2.1.1"
+            }
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "requires": {
+                "arr-flatten": "1.1.0"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "ascli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+            "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+            "requires": {
+                "colour": "0.7.1",
+                "optjs": "3.2.2"
+            }
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
+        },
+        "async-each": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "binary-extensions": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+        },
+        "blocking-proxy": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/blocking-proxy/-/blocking-proxy-0.0.5.tgz",
+            "integrity": "sha1-RikF4Nz76pcPQao3Ij3anAexkSs=",
+            "dev": true,
+            "requires": {
+                "minimist": "1.2.0"
+            }
+        },
+        "boom": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+            "dev": true,
+            "requires": {
+                "hoek": "4.2.0"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
+        },
+        "bytebuffer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+            "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+            "requires": {
+                "long": "3.2.0"
+            }
+        },
+        "camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "1.1.0",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "0.1.0",
+                "strip-ansi": "0.3.0",
+                "supports-color": "0.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+                    "dev": true
+                }
+            }
+        },
+        "chokidar": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+            "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+            "requires": {
+                "anymatch": "1.3.2",
+                "async-each": "1.0.1",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0"
+            }
+        },
+        "clang-format": {
+            "version": "1.0.49",
+            "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.49.tgz",
+            "integrity": "sha1-v1L0InfUHtNhhZH4cUWs9krOt+Y=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2",
+                "glob": "7.1.2",
+                "resolve": "1.5.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                }
+            }
+        },
+        "cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "colour": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+            "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+        },
+        "combined-stream": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+            "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concurrently": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.5.1.tgz",
+            "integrity": "sha512-689HrwGw8Rbk1xtV9C4dY6TPJAvIYZbRbnKSAtfJ7tHqICFGoZ0PCWYjxfmerRyxBG0o3sbG3pe7N8vqPwIHuQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "0.5.1",
+                "commander": "2.6.0",
+                "date-fns": "1.29.0",
+                "lodash": "4.17.4",
+                "rx": "2.3.24",
+                "spawn-command": "0.0.2-1",
+                "supports-color": "3.2.3",
+                "tree-kill": "1.2.0"
+            }
+        },
+        "core-js": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+            "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cryptiles": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+            "dev": true,
+            "requires": {
+                "boom": "5.2.0"
+            },
+            "dependencies": {
+                "boom": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.0"
+                    }
+                }
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
+        },
+        "date-fns": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+            "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "dev": true,
+            "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.0",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
+        },
+        "es6-promise": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+            "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "requires": {
+                "fill-range": "2.2.3"
+            }
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "requires": {
+                "for-in": "1.0.2"
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            }
+        },
+        "glob": {
+            "version": "5.0.15",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+            "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            }
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "requires": {
+                "is-glob": "2.0.1"
+            }
+        },
+        "globby": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+            "dev": true,
+            "requires": {
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                }
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "dev": true,
+            "requires": {
+                "ajv": "5.5.1",
+                "har-schema": "2.0.0"
+            }
+        },
+        "has-ansi": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "0.2.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+                    "dev": true
+                }
+            }
+        },
+        "has-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+            "dev": true
+        },
+        "hawk": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+            "dev": true,
+            "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+            }
+        },
+        "hoek": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+            "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+            "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+            "dev": true,
+            "requires": {
+                "agent-base": "2.1.1",
+                "debug": "2.6.9",
+                "extend": "3.0.1"
+            }
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+        },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "requires": {
+                "binary-extensions": "1.11.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "requires": {
+                "number-is-nan": "1.0.1"
+            }
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+            "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "1.0.1"
+            }
+        },
+        "is-path-inside": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "1.0.2"
+            }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "requires": {
+                "isarray": "1.0.0"
+            }
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "jasmine": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+            "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "glob": "7.1.2",
+                "jasmine-core": "2.8.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                }
+            }
+        },
+        "jasmine-core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+            "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+            "dev": true
+        },
+        "jasminewd2": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-2.2.0.tgz",
+            "integrity": "sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=",
+            "dev": true
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "jszip": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+            "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+            "dev": true,
+            "requires": {
+                "core-js": "2.3.0",
+                "es6-promise": "3.0.2",
+                "lie": "3.1.1",
+                "pako": "1.0.6",
+                "readable-stream": "2.0.6"
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "1.1.6"
+            }
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "requires": {
+                "invert-kv": "1.0.0"
+            }
+        },
+        "lie": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "dev": true,
+            "requires": {
+                "immediate": "3.0.6"
+            }
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
+        },
+        "long": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+            "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+            }
+        },
+        "mime-db": {
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+            "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.17",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+            "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.30.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "1.1.8"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                }
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                    "dev": true
+                }
+            }
+        },
+        "options": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+            "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+            "dev": true
+        },
+        "optjs": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+            "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "requires": {
+                "lcid": "1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+            "dev": true
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "protobufjs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.0.tgz",
+            "integrity": "sha1-QiMGMjPqlqwGPKK1VANSBNtST6E=",
+            "requires": {
+                "ascli": "1.0.1",
+                "bytebuffer": "5.0.1",
+                "glob": "5.0.15",
+                "yargs": "3.32.0"
+            }
+        },
+        "protractor": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.2.0.tgz",
+            "integrity": "sha1-0/ObGV6F81Oa2djLZWCp0rYyl8Q=",
+            "dev": true,
+            "requires": {
+                "@types/node": "6.0.92",
+                "@types/q": "0.0.32",
+                "@types/selenium-webdriver": "2.53.43",
+                "blocking-proxy": "0.0.5",
+                "chalk": "1.1.3",
+                "glob": "7.1.2",
+                "jasmine": "2.8.0",
+                "jasminewd2": "2.2.0",
+                "optimist": "0.6.1",
+                "q": "1.4.1",
+                "saucelabs": "1.3.0",
+                "selenium-webdriver": "3.6.0",
+                "source-map-support": "0.4.18",
+                "webdriver-js-extender": "1.0.0",
+                "webdriver-manager": "12.0.6"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "6.0.92",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
+                    "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
+                    "dev": true
+                },
+                "adm-zip": {
+                    "version": "0.4.7",
+                    "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+                    "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "semver": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                    "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                },
+                "webdriver-manager": {
+                    "version": "12.0.6",
+                    "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.0.6.tgz",
+                    "integrity": "sha1-PfGkgZdwELTL+MnYXHpXeCjA5ws=",
+                    "dev": true,
+                    "requires": {
+                        "adm-zip": "0.4.7",
+                        "chalk": "1.1.3",
+                        "del": "2.2.2",
+                        "glob": "7.1.2",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "q": "1.4.1",
+                        "request": "2.83.0",
+                        "rimraf": "2.6.2",
+                        "semver": "5.4.1",
+                        "xml2js": "0.4.19"
+                    }
+                }
+            }
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "q": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+            "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+            "dev": true
+        },
+        "randomatic": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+            "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "readdirp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+            "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.0.6",
+                "set-immediate-shim": "1.0.1"
+            }
+        },
+        "reflect-metadata": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.10.tgz",
+            "integrity": "sha1-tPg3BEFqytiZiMmxVjXUfgO5NEo="
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "requires": {
+                "is-equal-shallow": "0.1.3"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "request": {
+            "version": "2.83.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+            }
+        },
+        "resolve": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+            "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+            "dev": true,
+            "requires": {
+                "path-parse": "1.0.5"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                }
+            }
+        },
+        "rx": {
+            "version": "2.3.24",
+            "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
+            "integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=",
+            "dev": true
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "saucelabs": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
+            "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
+            "dev": true,
+            "requires": {
+                "https-proxy-agent": "1.0.0"
+            }
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "selenium-webdriver": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
+            "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
+            "dev": true,
+            "requires": {
+                "jszip": "3.1.5",
+                "rimraf": "2.6.2",
+                "tmp": "0.0.30",
+                "xml2js": "0.4.19"
+            }
+        },
+        "semver": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+            "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+            "dev": true
+        },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+        },
+        "sntp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+            "dev": true,
+            "requires": {
+                "hoek": "4.2.0"
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-support": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "requires": {
+                "source-map": "0.5.7"
+            }
+        },
+        "spawn-command": {
+            "version": "0.0.2-1",
+            "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+            "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+            }
+        },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "supports-color": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+            "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+            "dev": true,
+            "requires": {
+                "has-flag": "1.0.0"
+            }
+        },
+        "tmp": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
+            "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            }
+        },
+        "tree-kill": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
+            "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
+            "dev": true
+        },
+        "tsickle": {
+            "version": "0.25.5",
+            "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.25.5.tgz",
+            "integrity": "sha512-CgOT/1WqOKtE1fyvqB+kTJ7bizE33xj1TyUIzGbxJBGCbQmknCrZbb35DtxMiK6pJo4CrPyoS8iGFddfHKtSNA==",
+            "requires": {
+                "minimist": "1.2.0",
+                "mkdirp": "0.5.1",
+                "source-map": "0.5.7",
+                "source-map-support": "0.4.18"
+            }
+        },
+        "tslib": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
+            "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
+        },
+        "tsutils": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.1.tgz",
+            "integrity": "sha1-9Nlc4zkciXHkblTEzw7bCiHdWyQ=",
+            "requires": {
+                "tslib": "1.8.0"
+            }
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "typescript": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+            "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w=="
+        },
+        "ultron": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+            "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+            "dev": true
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+            }
+        },
+        "webdriver-js-extender": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-1.0.0.tgz",
+            "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
+            "dev": true,
+            "requires": {
+                "@types/selenium-webdriver": "2.53.43",
+                "selenium-webdriver": "2.53.3"
+            },
+            "dependencies": {
+                "sax": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
+                    "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk=",
+                    "dev": true
+                },
+                "selenium-webdriver": {
+                    "version": "2.53.3",
+                    "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
+                    "integrity": "sha1-0p/1qVff8aG0ncRXdW5OS/vc4IU=",
+                    "dev": true,
+                    "requires": {
+                        "adm-zip": "0.4.4",
+                        "rimraf": "2.6.2",
+                        "tmp": "0.0.24",
+                        "ws": "1.1.5",
+                        "xml2js": "0.4.4"
+                    }
+                },
+                "tmp": {
+                    "version": "0.0.24",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
+                    "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
+                    "dev": true
+                },
+                "xml2js": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
+                    "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
+                    "dev": true,
+                    "requires": {
+                        "sax": "0.6.1",
+                        "xmlbuilder": "9.0.4"
+                    }
+                }
+            }
+        },
+        "window-size": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "ws": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+            "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+            "dev": true,
+            "requires": {
+                "options": "0.0.6",
+                "ultron": "1.0.2"
+            }
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dev": true,
+            "requires": {
+                "sax": "1.2.4",
+                "xmlbuilder": "9.0.4"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+            "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+            "dev": true
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yargs": {
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+            "requires": {
+                "camelcase": "2.1.1",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "os-locale": "1.4.0",
+                "string-width": "1.0.2",
+                "window-size": "0.1.4",
+                "y18n": "3.2.1"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix file rerooting issue using closure_ts_binary macro which
reroots all transitive sources before invoking closure_js_binary

Allow angularjs to be imported as a commonJS module using internal
node_module rule

Functioning hello world example of dev and prod bundles being served
from the same path for different servers