### PR TITLE
Produce production mode JS as a tree artifact.

### DIFF
--- a/examples/es6_output/es6_output_test.sh
+++ b/examples/es6_output/es6_output_test.sh
@@ -2,17 +2,17 @@
 set -e
 
 # should not down-level ES2015 syntax, eg. `class`
-readonly GREETER_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/greeter.closure.js)
+readonly GREETER_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/es6_output_lib.prod/build_bazel_rules_typescript/examples/es6_output/greeter.js)
 if [[ "$GREETER_JS" != *"class Greeter"* ]]; then
-  echo "Expected greeter.closure.js to contain 'class Greeter' but was"
+  echo "Expected greeter.js to contain 'class Greeter' but was"
   echo "$GREETER_JS"
   exit 1
 fi
 
 # should have native ES Module format
-readonly MAIN_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/main.closure.js)
+readonly MAIN_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/es6_output_lib.prod/build_bazel_rules_typescript/examples/es6_output/main.js)
 if [[ "$MAIN_JS" != *"import { Greeter }"* ]]; then
-  echo "Expected main.closure.js to contain 'import { Greeter }' but was"
+  echo "Expected main.js to contain 'import { Greeter }' but was"
   echo "$MAIN_JS"
   exit 1
 fi

--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -97,6 +97,12 @@ def tsc_wrapped_tsconfig(ctx,
 
   if config["compilerOptions"]["target"] == "es6":
     config["compilerOptions"]["module"] = "es2015"
+    productionModeOutputTree = "/".join([
+      ctx.label.package,
+      ctx.label.name + ".prod",
+    ])
+    config["bazelOptions"]["productionModeOutputTree"] = productionModeOutputTree
+
   else:
     # The "typescript.es5_sources" provider is expected to work
     # in both nodejs and in browsers.

--- a/internal/common/compilation.bzl
+++ b/internal/common/compilation.bzl
@@ -93,7 +93,8 @@ def _collect_transitive_dts(ctx, deep=True):
       type_blacklisted_declarations=type_blacklisted_declarations
   )
 
-def _outputs(ctx, label):
+# FIXME(alexeagle): maybe remove this helper
+def _outputs(ctx, label, closure_file_artifacts = True):
   """Returns closure js, devmode js, and .d.ts output files.
 
   Args:
@@ -114,7 +115,8 @@ def _outputs(ctx, label):
     basename = "/".join(input_file.short_path.split("/")[trim:])
     dot = basename.rfind(".")
     basename = basename[:dot]
-    closure_js_files += [ctx.new_file(basename + ".closure.js")]
+    if closure_file_artifacts:
+      closure_js_files += [ctx.new_file(basename + ".closure.js")]
     devmode_js_files += [ctx.new_file(basename + ".js")]
     declaration_files += [ctx.new_file(basename + ".d.ts")]
   return struct(
@@ -131,7 +133,7 @@ def compile_ts(ctx,
                devmode_compile_action=None,
                jsx_factory=None,
                tsc_wrapped_tsconfig=None,
-               outputs=_outputs):
+               declare_outputs=_outputs):
   """Creates actions to compile TypeScript code.
 
   This rule is shared between ts_library and ts_declaration.
@@ -173,11 +175,6 @@ def compile_ts(ctx,
       if f.path.endswith(".d.ts"):
         src_declarations += [f]
         continue
-
-  outs = outputs(ctx, ctx.label)
-  transpiled_closure_js = outs.closure_js
-  transpiled_devmode_js = outs.devmode_js
-  gen_declarations = outs.declarations
 
   if has_sources and ctx.attr.runtime != "nodejs":
     # Note: setting this variable controls whether tsickle is run at all.
@@ -221,10 +218,22 @@ def compile_ts(ctx,
       tsickle_externs=tsickle_externs_path,
       type_blacklisted_declarations=type_blacklisted_declarations,
       allowed_deps=allowed_deps)
+
   # Do not produce declarations in ES6 mode, tsickle cannot produce correct
   # .d.ts (or even errors) from the altered Closure-style JS emit.
   tsconfig_es6["compilerOptions"]["declaration"] = False
   tsconfig_es6["compilerOptions"].pop("declarationDir")
+
+
+  if tsconfig_es6["bazelOptions"]["productionModeOutputTree"]:
+    outs = declare_outputs(ctx, ctx.label, closure_file_artifacts = False)
+    transpiled_closure_js = [ctx.experimental_new_directory(ctx.label.name + ".prod")]
+  else:
+    outs = declare_outputs(ctx, ctx.label)
+    transpiled_closure_js = outs.closure_js
+  transpiled_devmode_js = outs.devmode_js
+  gen_declarations = outs.declarations
+
   outputs = transpiled_closure_js + tsickle_externs
   if perf_trace and has_sources:
     perf_trace_file = ctx.new_file(ctx.label.name + ".es6.trace")

--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -311,8 +311,12 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
     }
     fileName = this.flattenOutDir(fileName);
     if (!this.bazelOpts.es5Mode) {
-      // Write ES6 transpiled files to *.closure.js.
-      if (this.bazelOpts.locale) {
+      // Write ES6 transpiled files to a distinct output, to avoid colliding
+      // with devmode outputs.
+      // We either create a TreeArtifact, or write them as *.closure.js.
+      if (this.bazelOpts.productionModeOutputTree) {
+        fileName = path.join(this.bazelOpts.productionModeOutputTree, this.bazelOpts.workspaceName, fileName);
+      } else if (this.bazelOpts.locale) {
         // i18n paths are required to end with __locale.js so we put
         // the .closure segment before the __locale
         fileName = fileName.replace(/(__[^\.]+)?\.js$/, '.closure$1.js');

--- a/internal/tsc_wrapped/tsconfig.ts
+++ b/internal/tsc_wrapped/tsconfig.ts
@@ -45,6 +45,13 @@ export interface BazelOptions {
   /** Write generated externs to the given path. */
   tsickleExternsPath: string;
 
+  /** Write production mode JS files to this directory (a TreeArtifact) */
+  // NOTE: we might want to factor es5Mode as a special value for this option
+  // and remove it.
+  // TODO: consider just writing the tsickle generated externs into this tree
+  // and drop the extra declared output for it.
+  productionModeOutputTree: string;
+
   /** Paths of declarations whose types must not appear in result .d.ts. */
   typeBlackListPaths: string[];
 


### PR DESCRIPTION
BREAKING CHANGE:
We no longer produce .closure.js files in Bazel. Instead, we create a path/to/label.prod directory as a
Bazel TreeArtifact (see goo.gl/tkmijs). This is similar semantics to just writing a zip file of whatever
outputs we want in production mode, without overwriting outputs from other rules.
Downstream consumers should just flatten the directories underneath the artifacts they receive.


Note: we'll probably update the es6_consumer to re-use a helper like prodmode_js_sources.bzl which provides the aspect to walk dependencies and a utility to flatten the TreeArtifacts.

Paired with @mrmeku 