### PR TITLE
Expose a function which reroots production (.closure.js) files.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,3 +46,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 go_rules_dependencies()
 
 go_register_toolchains()
+
+http_archive(
+    name = "io_bazel",
+    url = "https://github.com/bazelbuild/bazel/releases/download/0.9.0/bazel-0.9.0-dist.zip",
+    sha256 = "efb28fed4ffcfaee653e0657f6500fc4cbac61e32104f4208da385676e76312a",
+)

--- a/defs.bzl
+++ b/defs.bzl
@@ -19,7 +19,6 @@ Users should not load files under "/internal"
 load("//internal:build_defs.bzl", _ts_library = "ts_library")
 load("//internal:ts_config.bzl", _ts_config = "ts_config")
 load("//internal/devserver:ts_devserver.bzl", _ts_devserver = "ts_devserver_macro")
-load("//internal:ts_repositories.bzl", _ts_repositories = "ts_repositories")
 load("//internal/karma:ts_web_test.bzl", _ts_web_test = "ts_web_test_macro")
 
 ts_library = _ts_library

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
         "types.d.ts",
     ],
     tsconfig = ":tsconfig.json",
+    deps = ["//examples/generated_ts"],
 )
 
 ts_library(
@@ -32,5 +33,6 @@ ts_library(
     deps = [
         ":foo_ts_library",
         "//examples/some_library:lib",
+        "//examples/generated_ts",
     ],
 )

--- a/examples/bar.ts
+++ b/examples/bar.ts
@@ -16,9 +16,12 @@
  */
 
 import {Greeter} from 'examples/foo';
+import {a} from 'examples/generated_ts/foo';
 // Repro for #31, should automatically discover @types/node
 import * as fs from 'fs';
 import {cool} from 'some-lib';
 import * as ts from 'typescript';
 
 import {greeter} from './foo';
+
+console.log(Greeter, fs, cool, ts, greeter, a);

--- a/examples/es5_output/BUILD.bazel
+++ b/examples/es5_output/BUILD.bazel
@@ -1,21 +1,8 @@
-load("//:defs.bzl", "ts_library")
 load(":es5_consumer.bzl", "es5_consumer")
-
-genrule(
-  name = "generated_ts",
-  outs = ["generated.ts"],
-  cmd = "echo 'export const gen = 1;' > $@",
-)
-
-ts_library(
-    name = "lib",
-    srcs = glob(["*.ts"]) + [":generated.ts"],
-    deps = ["//examples/es5_output/rand"],
-)
 
 es5_consumer(
     name = "es5_output",
-    deps = [":lib"],
+    deps = ["//examples:bar_ts_library"],
 )
 
 sh_test(

--- a/examples/es5_output/a.ts
+++ b/examples/es5_output/a.ts
@@ -1,2 +1,0 @@
-import {rand} from './rand/rand';
-export const a = rand();

--- a/examples/es5_output/b.ts
+++ b/examples/es5_output/b.ts
@@ -1,6 +1,0 @@
-import * as tsickle from 'tsickle';
-
-import {a} from './a';
-import {gen} from './generated';
-
-console.log(a, gen, tsickle.EXTERNS_HEADER);

--- a/examples/es5_output/es5_consumer.bzl
+++ b/examples/es5_output/es5_consumer.bzl
@@ -15,11 +15,12 @@
 """Example of a rule that requires ES5 inputs.
 """
 
+load("@build_bazel_rules_nodejs//internal:node.bzl", "sources_aspect")
+
 def _es5_consumer(ctx):
   sources = depset()
   for d in ctx.attr.deps:
-    if hasattr(d, "typescript"):
-      sources += d.typescript.es5_sources
+    sources += d.node_sources
 
   return [DefaultInfo(
       files = sources,
@@ -29,6 +30,6 @@ def _es5_consumer(ctx):
 es5_consumer = rule(
     implementation = _es5_consumer,
     attrs = {
-        "deps": attr.label_list()
+        "deps": attr.label_list(aspects = [sources_aspect])
     }
 )

--- a/examples/es5_output/es5_output_test.sh
+++ b/examples/es5_output/es5_output_test.sh
@@ -2,38 +2,39 @@
 set -e
 
 # should produce named UMD modules
-readonly A_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es5_output/a.js)
-if [[ "$A_JS" != *"define(\"build_bazel_rules_typescript/examples/es5_output/a\","* ]]; then
-  echo "Expected a.js to declare named module, but was"
+readonly LIBRARY_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/some_library/library.js)
+if [[ "$LIBRARY_JS" != *"define(\"build_bazel_rules_typescript/examples/some_library/library\""* ]]; then
+  echo "Expected library.js to declare named module, but was"
   echo "$A_JS"
   exit 1
 fi
 
 # should give a name to required modules
-readonly B_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es5_output/b.js)
-if [[ "$B_JS" != *"require(\"build_bazel_rules_typescript/examples/es5_output/a\")"* ]]; then
-  echo "Expected b.js to require named module a, but was"
-  echo "$B_JS"
+readonly BAR_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/bar.js)
+if [[ "$BAR_JS" != *"require(\"build_bazel_rules_typescript/examples/foo\")"* ]]; then
+  echo "Expected bar.js to require named module foo, but was"
+  echo "$BAR_JS"
   exit 1
 fi
 
 # should give a name to required modules from other compilation unit
-if [[ "$A_JS" != *"require(\"build_bazel_rules_typescript/examples/es5_output/rand/rand\")"* ]]; then
-  echo "Expected a.js to require named module c, but was"
-  echo "$A_JS"
+readonly FOO_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/bar.js)
+if [[ "$FOO_JS" != *"require(\"build_bazel_rules_typescript/examples/some_library/library\")"* ]]; then
+  echo "Expected bar.js to require named module library, but was"
+  echo "$FOO_JS"
   exit 1
 fi
 
 # should give a name to required generated modules without bazel-bin
-if [[ "$B_JS" != *"require(\"build_bazel_rules_typescript/examples/es5_output/generated\")"* ]]; then
-  echo "Expected b.js to require named module generated, but was"
-  echo "$B_JS"
+if [[ "$FOO_JS" != *"require(\"build_bazel_rules_typescript/examples/generated_ts/foo\")"* ]]; then
+  echo "Expected foo.js to require generated named module foo, but was"
+  echo "$FOO_JS"
   exit 1
 fi
 
 # should not give a module name to external modules
-if [[ "$B_JS" != *"require(\"tsickle\")"* ]]; then
-  echo "Expected b.js to require tsickle by its original name, but was"
-  echo "$B_JS"
+if [[ "$FOO_JS" != *"require(\"typescript\")"* ]]; then
+  echo "Expected foo.js to require typescript by its original name, but was"
+  echo "$FOO_JS"
   exit 1
 fi

--- a/examples/es5_output/rand/BUILD.bazel
+++ b/examples/es5_output/rand/BUILD.bazel
@@ -1,7 +1,0 @@
-load("//:defs.bzl", "ts_library")
-
-ts_library(
-    name = "rand",
-    srcs = ["rand.ts"],
-    visibility = ["//examples/es5_output:__subpackages__"],
-)

--- a/examples/es5_output/rand/rand.ts
+++ b/examples/es5_output/rand/rand.ts
@@ -1,3 +1,0 @@
-export function rand(): number {
-  return 1;  // Well, not that random...
-}

--- a/examples/es6_output/BUILD.bazel
+++ b/examples/es6_output/BUILD.bazel
@@ -14,17 +14,11 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//:defs.bzl", "ts_library")
 load(":es6_consumer.bzl", "es6_consumer")
-
-ts_library(
-    name = "es6_output_lib",
-    srcs = glob(["*.ts"]),
-)
 
 es6_consumer(
     name = "es6_output",
-    deps = [":es6_output_lib"],
+    deps = ["//examples:bar_ts_library"],
 )
 
 sh_test(

--- a/examples/es6_output/es6_consumer.bzl
+++ b/examples/es6_output/es6_consumer.bzl
@@ -15,15 +15,14 @@
 """Example of a rule that requires ES6 inputs.
 """
 
+load("//:internal/common/reroot_prod_files.bzl", "reroot_prod_files")
+
 def _es6_consumer(ctx):
-  sources = depset()
-  for d in ctx.attr.deps:
-    if hasattr(d, "typescript"):
-      sources += d.typescript.es6_sources
+  rerooted_prod_files = reroot_prod_files(ctx)
 
   return [DefaultInfo(
-      files = sources,
-      runfiles = ctx.runfiles(sources.to_list()),
+      files = rerooted_prod_files,
+      runfiles = ctx.runfiles(rerooted_prod_files.to_list()),
   )]
 
 es6_consumer = rule(

--- a/examples/es6_output/es6_output_test.sh
+++ b/examples/es6_output/es6_output_test.sh
@@ -2,17 +2,17 @@
 set -e
 
 # should not down-level ES2015 syntax, eg. `class`
-readonly GREETER_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/greeter.closure.js)
-if [[ "$GREETER_JS" != *"class Greeter"* ]]; then
-  echo "Expected greeter.closure.js to contain 'class Greeter' but was"
-  echo "$GREETER_JS"
+readonly FOO_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/es6_output.prod/examples/foo.js)
+if [[ "$FOO_JS" != *"class Greeter"* ]]; then
+  echo "Expected foo.js to contain 'class Greeter' but was"
+  echo "$FOO_JS"
   exit 1
 fi
 
-# should have native ES Module format
-readonly MAIN_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/main.closure.js)
-if [[ "$MAIN_JS" != *"import { Greeter }"* ]]; then
-  echo "Expected main.closure.js to contain 'import { Greeter }' but was"
-  echo "$MAIN_JS"
+# should not down-level ES2015 syntax, eg. `class`
+readonly LIBRARY_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/es6_output.prod/examples/some_library/library.js)
+if [[ "$LIBRARY_JS" != *"export const cool = 1;"* ]]; then
+  echo "Expected library.js to contain 'export const cool = 1;' but was"
+  echo "$LIBRARY_JS"
   exit 1
 fi

--- a/examples/es6_output/greeter.ts
+++ b/examples/es6_output/greeter.ts
@@ -1,6 +1,0 @@
-export class Greeter {
-  private greeting = 'hello, world';
-  greet() {
-    return this.greeting;
-  }
-}

--- a/examples/es6_output/main.ts
+++ b/examples/es6_output/main.ts
@@ -1,3 +1,0 @@
-import {Greeter} from './greeter';
-
-console.log(new Greeter().greet());

--- a/examples/generated_ts/BUILD.bazel
+++ b/examples/generated_ts/BUILD.bazel
@@ -1,5 +1,7 @@
 load("//:defs.bzl", "ts_library")
 
+package(default_visibility = ["//visibility:public"])
+
 genrule(
   name = "foo_ts",
   outs = ["foo.ts"],

--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -21,7 +21,7 @@ load(":executables.bzl", "get_tsc")
 # This is created by the ts_repositories() repository rule
 load("@build_bazel_rules_typescript_install//:tsconfig.bzl", "get_default_tsconfig")
 load(":common/tsconfig.bzl", "create_tsconfig")
-load(":ts_config.bzl", "TsConfig")
+load(":ts_config.bzl", "TsConfigInfo")
 
 def _compile_action(ctx, inputs, outputs, config_file_path):
   externs_files = []
@@ -42,8 +42,8 @@ def _compile_action(ctx, inputs, outputs, config_file_path):
                             if f.path.endswith(".ts") or f.path.endswith(".json")]
   if ctx.file.tsconfig:
     action_inputs += [ctx.file.tsconfig]
-    if TsConfig in ctx.attr.tsconfig:
-      action_inputs += ctx.attr.tsconfig[TsConfig].deps
+    if TsConfigInfo in ctx.attr.tsconfig:
+      action_inputs += ctx.attr.tsconfig[TsConfigInfo].deps
 
   # One at-sign makes this a params-file, enabling the worker strategy.
   # Two at-signs escapes the argument so it's passed through to tsc_wrapped
@@ -77,6 +77,9 @@ def tsc_wrapped_tsconfig(ctx,
                          devmode_manifest=None,
                          jsx_factory=None,
                          **kwargs):
+  """TODO(alexeagle)
+
+  """
 
   # The location of tsconfig.json is interpreted as the root of the project
   # when it is passed to the TS compiler with the `-p` option:
@@ -126,6 +129,7 @@ def _ts_library_impl(ctx):
 
   Args:
     ctx: the context.
+
   Returns:
     the struct returned by the call to compile_ts.
   """

--- a/internal/common/compilation.bzl
+++ b/internal/common/compilation.bzl
@@ -294,6 +294,11 @@ def compile_ts(ctx,
   if not is_library:
     files += depset(tsickle_externs)
 
+  transitive_es6_sources = es6_sources
+  for dep in ctx.attr.deps:
+    if hasattr(dep, "typescript"):
+      transitive_es6_sources += dep.typescript.transitive_es6_sources
+
   return {
       "files": files,
       "runfiles": ctx.runfiles(
@@ -308,6 +313,7 @@ def compile_ts(ctx,
           "declarations": declarations,
           "transitive_declarations": transitive_decls,
           "es6_sources": es6_sources,
+          "transitive_es6_sources": transitive_es6_sources,
           "es5_sources": es5_sources,
           "devmode_manifest": devmode_manifest,
           "type_blacklisted_declarations": type_blacklisted_declarations,

--- a/internal/common/compilation.bzl
+++ b/internal/common/compilation.bzl
@@ -99,6 +99,7 @@ def _outputs(ctx, label):
   Args:
     ctx: ctx.
     label: Label. package label.
+
   Returns:
     A struct of file lists for different output types.
   """
@@ -147,6 +148,7 @@ def compile_ts(ctx,
     jsx_factory: optional string. Enables overriding jsx pragma.
     tsc_wrapped_tsconfig: function that produces a tsconfig object.
     outputs: function from a ctx to the expected compilation outputs.
+
   Returns:
     struct that will be returned by the rule implementation.
   """

--- a/internal/common/module_mappings.bzl
+++ b/internal/common/module_mappings.bzl
@@ -20,6 +20,9 @@
 # TypeScript compiler and to editors.
 #
 
+"""Module mappings.
+"""
+
 def _get_deps(attrs, names):
   return [d for n in names if hasattr(attrs, n)
           for d in getattr(attrs, n)]
@@ -41,6 +44,16 @@ def get_module_mappings(label, attrs, srcs = [], workspace_name = None, mappings
   checking for collisions. If a module has a non-empty `module_root` attribute,
   all sources underneath it are treated as if they were rooted at a folder
   `module_name`.
+
+  Args:
+    label: TODO(alexeagle)
+    attrs: TODO(alexeagle)
+    srcs: TODO(alexeagle)
+    workspace_name: TODO(alexeagle)
+    mappings_attr: TODO(alexeagle)
+
+  Returns:
+    the module_mappings from the given attrs.
   """
   mappings = dict()
   all_deps =  _get_deps(attrs, names = _MODULE_MAPPINGS_DEPS_NAMES)

--- a/internal/common/reroot_prod_files.bzl
+++ b/internal/common/reroot_prod_files.bzl
@@ -1,0 +1,54 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Used by production rules to expose a file tree of only prod files.
+"""
+
+def reroot_prod_files(ctx):
+  """Returns a file tree containing only production files.
+
+  Args:
+    ctx: ctx.
+
+  Returns:
+    A file tree containing only production files.
+  """
+  
+  non_rerooted_prod_files = depset()
+  for dep in ctx.attr.deps:
+    if hasattr(dep, "typescript"):
+      non_rerooted_prod_files += dep.typescript.transitive_es6_sources
+    elif hasattr(dep, "closure_js_library"):
+      non_rerooted_prod_files += dep.closure_js_library.srcs
+    elif hasattr(dep, "files"):
+      non_rerooted_prod_files += dep.files
+    else:
+      fail(
+          ("%s is neither a TypeScript nor a Closure JS library producing rule." % dep.label) +
+          "\nDependencies must be ts_library, ts_declaration, or closure_js_library.")
+
+  rerooted_prod_files = depset()
+  for non_rerooted_prod_file in non_rerooted_prod_files:
+    rerooted_prod_file = ctx.actions.declare_file(
+      "%s.prod/%s" % (
+        ctx.label.name,
+        non_rerooted_prod_file.short_path.replace(".closure.js", ".js")))
+    ctx.actions.expand_template(
+      output = rerooted_prod_file,
+      template = non_rerooted_prod_file,
+      substitutions = {}
+    )
+    rerooted_prod_files += [rerooted_prod_file]
+    
+  return rerooted_prod_files

--- a/internal/common/tsconfig.bzl
+++ b/internal/common/tsconfig.bzl
@@ -14,29 +14,34 @@
 
 """Helpers for configuring the TypeScript compiler.
 """
-_DEBUG = False
 
 load(":common/module_mappings.bzl", "get_module_mappings")
+
+_DEBUG = False
 
 def create_tsconfig(ctx, files, srcs,
                     devmode_manifest=None, tsickle_externs=None, type_blacklisted_declarations=[],
                     out_dir=None, disable_strict_deps=False, allowed_deps=depset(),
                     extra_root_dirs=[], module_path_prefixes=None, module_roots=None):
-  """Creates an object representing the TypeScript configuration
-      to run the compiler under Bazel.
+  """Creates an object representing the TypeScript configuration to run the compiler under Bazel.
 
-      Args:
-        ctx: the skylark execution context
-        files: Labels of all TypeScript compiler inputs
-        srcs: Immediate sources being compiled, as opposed to transitive deps.
-        devmode_manifest: path to the manifest file to write for --target=es5
-        tsickle_externs: path to write tsickle-generated externs.js.
-        type_blacklisted_declarations: types declared in these files will never be
-            mentioned in generated .d.ts.
-        out_dir: directory for generated output. Default is ctx.bin_dir
-        disable_strict_deps: whether to disable the strict deps check
-        allowed_deps: the set of files that code in srcs may depend on (strict deps)
-        extra_root_dirs: Extra root dirs to be passed to tsc_wrapped.
+  Args:
+    ctx: the skylark execution context
+    files: Labels of all TypeScript compiler inputs
+    srcs: Immediate sources being compiled, as opposed to transitive deps.
+    devmode_manifest: path to the manifest file to write for --target=es5
+    tsickle_externs: path to write tsickle-generated externs.js.
+    type_blacklisted_declarations: types declared in these files will never be
+        mentioned in generated .d.ts.
+    out_dir: directory for generated output. Default is ctx.bin_dir
+    disable_strict_deps: whether to disable the strict deps check
+    allowed_deps: the set of files that code in srcs may depend on (strict deps)
+    extra_root_dirs: Extra root dirs to be passed to tsc_wrapped.
+    module_path_prefixes: TODO(alexeagle)
+    module_roots: TODO(alexeagle)
+
+  Returns:
+    TODO(alexeagle)
   """
   outdir_path = out_dir if out_dir != None else ctx.configuration.bin_dir.path
   # Callers can choose the filename for the tsconfig, but it must always live

--- a/internal/ts_config.bzl
+++ b/internal/ts_config.bzl
@@ -15,12 +15,12 @@
 """The ts_config rule allows users to express tsconfig.json file groups.
 """
 
-TsConfig = provider()
+TsConfigInfo = provider()
 
 def _ts_config_impl(ctx):
   files = depset()
   files += [ctx.file.src]
-  return [DefaultInfo(files = files), TsConfig(deps = ctx.files.deps)]
+  return [DefaultInfo(files = files), TsConfigInfo(deps = ctx.files.deps)]
 
 ts_config = rule(
     implementation = _ts_config_impl,

--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -289,7 +289,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
 
   writeFile(
       fileName: string, content: string, writeByteOrderMark: boolean,
-      onError: ((message: string) => void) | undefined,
+      onError: ((message: string) => void)|undefined,
       sourceFiles: ReadonlyArray<ts.SourceFile>): void {
     perfTrace.wrap(
         `writeFile ${fileName}`,
@@ -299,7 +299,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
 
   writeFileImpl(
       fileName: string, content: string, writeByteOrderMark: boolean,
-      onError: ((message: string) => void) | undefined,
+      onError: ((message: string) => void)|undefined,
       sourceFiles: ReadonlyArray<ts.SourceFile>): void {
     // Workaround https://github.com/Microsoft/TypeScript/issues/18648
     if ((this.options.module === ts.ModuleKind.AMD ||

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     },
     "scripts": {
         "pretest": "webdriver-manager update && bazel build examples/app:all",
-        "test": "concurrently \"bazel run examples/app:devserver\" protractor --kill-others --success first"
+        "test": "concurrently \"bazel run examples/app:devserver\" protractor --kill-others --success first",
+        "skylint": "bazel build @io_bazel//src/tools/skylark/java/com/google/devtools/skylark/skylint:Skylint && find . -type f -name \"*.bzl\" ! -path \"*/node_modules/*\" | xargs $(bazel info bazel-bin)/external/io_bazel/src/tools/skylark/java/com/google/devtools/skylark/skylint/Skylint"
     }
 }


### PR DESCRIPTION
This function is exposed so that production bundling rules
(rollup, closure, unglify etc.) can invoke this function
to get a file tree contianing only production files with
the .closure.js suffix stripped off.