### PR TITLE
Allow ts_library to contain only .d.ts files

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -17,8 +17,14 @@ package(default_visibility = ["//visibility:public"])
 load("//:defs.bzl", "ts_library")
 
 ts_library(
+    name = "declarations",
+    srcs = ["declarations.d.ts"],
+)
+
+ts_library(
     name = "foo_ts_library",
     srcs = [
+        ":declarations",
         "foo.ts",
         "types.d.ts",
     ],

--- a/examples/declarations.d.ts
+++ b/examples/declarations.d.ts
@@ -1,0 +1,1 @@
+declare const globalVariable = 'globalVariable';

--- a/examples/foo.ts
+++ b/examples/foo.ts
@@ -24,5 +24,7 @@ export class Greeter implements Polite {
   }
 }
 
+console.log(globalVariable);
+
 export const greeter = new Greeter('Hello, world!');
 greeter.greet().then(msg => { document.body.innerHTML = msg; });

--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -55,6 +55,10 @@ def _compile_action(ctx, inputs, outputs, config_file_path):
     arguments = ["-p", config_file_path]
     mnemonic = "tsc"
 
+  outputs = non_externs_files
+  if not outputs:
+    return
+
   ctx.action(
       progress_message = "Compiling TypeScript (devmode) %s" % ctx.label,
       mnemonic = mnemonic,


### PR DESCRIPTION
Fixes #24 
Previously having such a ts_library would error out because the es5 compilation step would not have any outputs (which makes sense since only the es6 compilation step produces the .externs file)
  