### PR TITLE
Remove hard-coded `jsxFactory`

### DIFF
--- a/internal/common/tsconfig.bzl
+++ b/internal/common/tsconfig.bzl
@@ -150,7 +150,8 @@ def create_tsconfig(ctx, files, srcs,
 
       # Interpret JSX as React calls (until someone asks for something different)
       "jsx": "react",
-      "jsxFactory": "React.createElement",
+      # Don't hardcode a default for jsxFactory, as this breaks TypeScript's
+      # support for JSX fragments in React.
 
       "noEmitOnError": False,
       "declaration": True,


### PR DESCRIPTION
React now supports [fragments](https://reactjs.org/docs/fragments.html#short-syntax) to enable components to return lists of elements without an explicit container.

```ts
<>
  <li>First</li>
  <li>Second</li>
</>
```

Unfortunately, TypeScript's support for this syntax breaks when `jsxFactory` is explicitly set:

```
error TS17016: JSX fragment is not supported when using --jsxFactory
```

Since TypeScript sets the same default for `jsxFactory` that the Bazel rule did, we can remove the hardcoded Bazel flag and let TypeScript do the right thing.