### PR TITLE
Clarify role of rules_nodejs in rules_typescript installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ containing:
 ```python
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+# rules_nodejs provides build rules related to NPM and Yarn package management.
+# These rules are used for modeling the dependencies between user TypeScript
+# code and NPM or Yarn packages.
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",
-    tag = "0.0.2", # check for the latest tag when you install
+    tag = "0.3.1", # check for the latest tag when you install
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
@@ -57,8 +60,8 @@ ts_setup_workspace()
 # See https://github.com/bazelbuild/rules_go#setup for the latest version.
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.8.1/rules_go-0.8.1.tar.gz",
-    sha256 = "90bb270d0a92ed5c83558b2797346917c46547f6f7103e648941ecdb6b9d0e72",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.9.0/rules_go-0.9.0.tar.gz",
+    sha256 = "4d8d6244320dd751590f9100cf39fd7a4b75cd901e1f3ffdfd6f048328883695",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ containing:
 ```python
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-# rules_nodejs provides build rules related to NPM and Yarn package management.
-# These rules are used for modeling the dependencies between user TypeScript
-# code and NPM or Yarn packages.
+# rules_nodejs provides build rules related to NPM and Yarn package management,
+# which are used for modeling the dependencies between user TypeScript code and
+# NPM or Yarn packages. It also provides testing and bundling rules that are
+# not specific to TypeScript (such as `jasmine_node_test` and `rollup_bundle`.)
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",
-    tag = "0.3.1", # check for the latest tag when you install
+    # Update the tag below to the latest rules_nodejs release when installing.
+    tag = "0.3.1",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")


### PR DESCRIPTION
I noticed the README did not explain why rules_nodejs is needed to use rules_typescript. I've attempted to provide a concise explanation. This stemmed from my attempt to better understand the boundaries between what rules_typescript and rules_nodejs are responsible for.

I also took this chance to update the rules_nodejs and rules_go releases referenced in the README.