### PR TITLE
Don't use types for 'tmp' in karma/index.ts

### DIFF
--- a/internal/karma/index.ts
+++ b/internal/karma/index.ts
@@ -5,7 +5,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as process from 'process';
-import * as tmp from 'tmp';
+const tmp = require('tmp');
 ///<reference types="lib.dom"/>
 
 /**


### PR DESCRIPTION
Fix for https://github.com/bazelbuild/rules_typescript/issues/134