### PR TITLE
Include .js files as inputs to ts_library actions.

### DIFF
--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -42,7 +42,7 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file):
     return struct()
 
   action_inputs = inputs + [f for f in ctx.files.node_modules + ctx.files._tsc_wrapped_deps
-                            if f.path.endswith(".ts") or f.path.endswith(".json")]
+                            if f.path.endswith(".js") or f.path.endswith(".ts") or f.path.endswith(".json")]
   if ctx.file.tsconfig:
     action_inputs += [ctx.file.tsconfig]
     if TsConfigInfo in ctx.attr.tsconfig:
@@ -176,7 +176,7 @@ ts_library = rule(
                 cfg="host"),
         "supports_workers": attr.bool(default = True),
         "tsickle_typed": attr.bool(default = True),
-        "_tsc_wrapped_deps": attr.label(default = Label("@build_bazel_rules_typescript_deps//:node_modules")),
+        "_tsc_wrapped_deps": attr.label(default = Label("@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules")),
         # @// is special syntax for the "main" repository
         # The default assumes the user specified a target "node_modules" in their
         # root BUILD file.
@@ -193,5 +193,5 @@ def tsc_library(**kwargs):
   ts_library(
       supports_workers = False,
       compiler = "//internal/tsc_wrapped:tsc",
-      node_modules = "@build_bazel_rules_typescript_deps//:node_modules",
+      node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
       **kwargs)

--- a/internal/karma/BUILD.bazel
+++ b/internal/karma/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
     name = "karma_concat_js",
     srcs = glob(["*.ts"]),
     module_name = "karma-concat-js",
+    node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")

--- a/internal/karma/package.json
+++ b/internal/karma/package.json
@@ -1,7 +1,6 @@
 {
   "description": "runtime dependences for ts_web_test rules",
   "devDependencies": {
-    "@types/tmp": "0.0.33",
     "jasmine-core": "2.8.0",
     "karma": "alexeagle/karma#fa1a84ac881485b5657cb669e9b4e5da77b79f0a",
     "karma-chrome-launcher": "2.2.0",

--- a/internal/ts_repositories.bzl
+++ b/internal/ts_repositories.bzl
@@ -19,7 +19,7 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "npm_install")
 
 def ts_setup_workspace():
   npm_install(
-      name = "build_bazel_rules_typescript_deps",
+      name = "build_bazel_rules_typescript_tsc_wrapped_deps",
       package_json = "@build_bazel_rules_typescript//internal/tsc_wrapped:package.json",
   )
   npm_install(

--- a/internal/tsc_wrapped/BUILD.bazel
+++ b/internal/tsc_wrapped/BUILD.bazel
@@ -18,7 +18,7 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "jasmine_node_test
 # Vanilla typescript compiler: run the tsc.js binary distributed by TypeScript
 nodejs_binary(
     name = "tsc",
-    node_modules = "@build_bazel_rules_typescript_deps//:node_modules",
+    node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
     entry_point = "typescript/lib/tsc.js",
     visibility = ["//internal:__subpackages__"],
 )
@@ -73,7 +73,7 @@ nodejs_binary(
     data = [
         ":tsc_wrapped",
     ],
-    node_modules = "@build_bazel_rules_typescript_deps//:node_modules",
+    node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
     entry_point = "build_bazel_rules_typescript/internal/tsc_wrapped/tsc_wrapped.js",
     templated_args = ["--node_options=--expose-gc"],
     visibility = ["//visibility:public"],

--- a/internal/tsc_wrapped/package.json
+++ b/internal/tsc_wrapped/package.json
@@ -1,12 +1,14 @@
 {
-  "description": "runtime dependencies to compile and run tsc_wrapped",
+  "description": "build-time dependencies to compile and run tsc_wrapped",
   "devDependencies": {
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "@types/source-map": "0.5.2",
+    "@types/tmp": "0.0.33",
     "protobufjs": "5.0.0",
     "tsickle": "0.25.5",
     "typescript": "2.5.3",
-    "tsutils": "2.12.1"
+    "tsutils": "2.12.1",
+    "tmp": "0.0.33"
   }
 }

--- a/internal/tsc_wrapped/worker.ts
+++ b/internal/tsc_wrapped/worker.ts
@@ -5,7 +5,7 @@ const ByteBuffer = require('bytebuffer');
 
 protobufjs.convertFieldsToCamelCase = true;
 
-const DEBUG = false;
+export const DEBUG = false;
 
 export function debug(...args: Array<{}>) {
   if (DEBUG) console.error.apply(console, args);


### PR DESCRIPTION
TS module resolution sometimes follows the main field in package.json to resolve them.
Also give explicit node_modules for the karma concat-js plugin instead of relying on the user.