### PR TITLE
Windows path fixes for tsc_wrapped

### DIFF
--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -18,7 +18,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["worker_protocol.proto"])
 
-load("//internal:build_defs.bzl", ts_library = "tsc_library")
+load("//internal:build_defs.bzl", "ts_library", "tsc_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "jasmine_node_test")
 
 # Vanilla typescript compiler: run the tsc.js binary distributed by TypeScript
@@ -30,7 +30,7 @@ nodejs_binary(
 )
 
 # Build our custom compiler using the vanilla one
-ts_library(
+tsc_library(
     name = "tsc_wrapped",
     srcs = glob([
       "tsc_wrapped/*.ts",

--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -4,6 +4,7 @@ import * as tsickle from 'tsickle';
 import * as ts from 'typescript';
 
 import {FileLoader} from './file_cache';
+import {normalizeSlashes} from './normalize_slashes';
 import * as perfTrace from './perf_trace';
 import {BazelOptions} from './tsconfig';
 import {DEBUG, debug} from './worker';
@@ -255,7 +256,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
     let fileName = this.rootDirsRelative(sf.fileName).replace(/(\.d)?\.tsx?$/, '');
 
     if (this.bazelOpts.moduleName) {
-      return path.join(this.bazelOpts.moduleName, path.relative(this.bazelOpts.package, fileName));
+      return normalizeSlashes(path.join(this.bazelOpts.moduleName, path.relative(this.bazelOpts.package, fileName)));
     }
 
     let workspace = this.bazelOpts.workspaceName;
@@ -277,7 +278,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
 
     // path/to/file ->
     // myWorkspace/path/to/file
-    return path.join(workspace, fileName);
+    return normalizeSlashes(path.join(workspace, fileName));
   }
 
   /** Loads a source file from disk (or the cache). */
@@ -381,6 +382,10 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
       return result;
     }
     return this.knownFiles.has(filePath);
+  }
+
+  getDefaultLibLocation(): string {
+    return path.dirname(this.getDefaultLibFileName({target: ts.ScriptTarget.ES5}));
   }
 
   getDefaultLibFileName(options: ts.CompilerOptions): string {

--- a/internal/tsc_wrapped/normalize_slashes.ts
+++ b/internal/tsc_wrapped/normalize_slashes.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2017 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as path from 'path';
+
+export function normalizeSlashes(path: string): string {
+    return path.replace(/\\/g, '/');
+}

--- a/internal/tsc_wrapped/strict_deps.ts
+++ b/internal/tsc_wrapped/strict_deps.ts
@@ -18,6 +18,7 @@
 import * as path from 'path';
 import * as ts from 'typescript';
 
+import {normalizeSlashes} from './normalize_slashes';
 import * as perfTrace from './perf_trace';
 import * as pluginApi from './plugin_api';
 
@@ -97,7 +98,7 @@ export function checkModuleDeps(
       const declFileName = sym.declarations[0].getSourceFile().fileName;
       if (allowedMap[stripExt(declFileName)]) continue;
       if (ignoredFilesPrefixes.some(p => declFileName.startsWith(p))) continue;
-      const importName = path.relative(rootDir, declFileName);
+      const importName = normalizeSlashes(path.relative(rootDir, declFileName));
       result.push({
         file: sf,
         start: modSpec.getStart(),

--- a/internal/tsc_wrapped/tsc_wrapped.ts
+++ b/internal/tsc_wrapped/tsc_wrapped.ts
@@ -7,6 +7,7 @@ import {PLUGIN as tsetsePlugin} from '../tsetse/runner';
 import {CompilerHost} from './compiler_host';
 import * as diagnostics from './diagnostics';
 import {CachedFileLoader, FileCache, FileLoader, UncachedFileLoader} from './file_cache';
+import {normalizeSlashes} from './normalize_slashes';
 import {wrap} from './perf_trace';
 import {PLUGIN as strictDepsPlugin} from './strict_deps';
 import {BazelOptions, parseTsconfig} from './tsconfig';
@@ -71,7 +72,7 @@ function runOneBuild(
     // Resolve the inputs to absolute paths to match TypeScript internals
     const resolvedInputs: {[path: string]: string} = {};
     for (const key of Object.keys(inputs)) {
-      resolvedInputs[path.resolve(key)] = inputs[key];
+      resolvedInputs[normalizeSlashes(path.resolve(key))] = inputs[key];
     }
     fileCache.updateCache(resolvedInputs);
   } else {
@@ -102,7 +103,7 @@ function runOneBuild(
     const ignoredFilesPrefixes = [bazelOpts.nodeModulesPrefix];
     if (options.rootDir) {
       ignoredFilesPrefixes.push(
-          path.resolve(options.rootDir, 'node_modules'));
+        path.resolve(options.rootDir, 'node_modules'));
     }
     program = strictDepsPlugin.wrap(program, {
       ...bazelOpts,

--- a/internal/tsc_wrapped/tsconfig.ts
+++ b/internal/tsc_wrapped/tsconfig.ts
@@ -18,6 +18,8 @@
 import * as path from 'path';
 import * as ts from 'typescript';
 
+import {normalizeSlashes} from './normalize_slashes';
+
 /**
  * The configuration block provided by the tsconfig "bazelOptions".
  * Note that all paths here are relative to the rootDir, not absolute nor
@@ -218,7 +220,7 @@ export function parseTsconfig(
     tsconfigFile: string, host: ts.ParseConfigHost = ts.sys):
     [ParsedTsConfig|null, ts.Diagnostic[]|null, {target: string}] {
   // TypeScript expects an absolute path for the tsconfig.json file
-  tsconfigFile = path.resolve(tsconfigFile);
+  tsconfigFile = normalizeSlashes(path.resolve(tsconfigFile));
 
   const {config, error} = ts.readConfigFile(tsconfigFile, host.readFile);
   if (error) {
@@ -237,7 +239,7 @@ export function parseTsconfig(
   // we have to repeat some of their logic to get the user's bazelOptions.
   if (config.extends) {
     let userConfigFile =
-        path.resolve(path.dirname(tsconfigFile), config.extends);
+        normalizeSlashes(path.resolve(path.dirname(tsconfigFile), config.extends));
     if (!userConfigFile.endsWith('.json')) userConfigFile += '.json';
     const {config: userConfig, error} =
         ts.readConfigFile(userConfigFile, host.readFile);
@@ -279,14 +281,14 @@ export function parseTsconfig(
   // parseJsonConfigFileContent (because TypeScript doesn't know
   // about them). Transform them to also be absolute here.
   bazelOpts.compilationTargetSrc = bazelOpts.compilationTargetSrc.map(
-      f => path.resolve(options.rootDir!, f));
+      f => normalizeSlashes(path.resolve(options.rootDir!, f)));
   bazelOpts.allowedStrictDeps =
-      bazelOpts.allowedStrictDeps.map(f => path.resolve(options.rootDir!, f));
+      bazelOpts.allowedStrictDeps.map(f => normalizeSlashes(path.resolve(options.rootDir!, f)));
   bazelOpts.typeBlackListPaths =
-      bazelOpts.typeBlackListPaths.map(f => path.resolve(options.rootDir!, f));
+      bazelOpts.typeBlackListPaths.map(f => normalizeSlashes(path.resolve(options.rootDir!, f)));
   if (bazelOpts.nodeModulesPrefix) {
     bazelOpts.nodeModulesPrefix =
-        path.resolve(options.rootDir!, bazelOpts.nodeModulesPrefix);
+    normalizeSlashes(path.resolve(options.rootDir!, bazelOpts.nodeModulesPrefix));
   }
 
   let disabledTsetseRules: string[] = [];

--- a/internal/tsc_wrapped/tsconfig_test.ts
+++ b/internal/tsc_wrapped/tsconfig_test.ts
@@ -18,6 +18,7 @@
 import * as path from 'path';
 import * as ts from 'typescript';
 
+import {normalizeSlashes} from './normalize_slashes';
 import {parseTsconfig} from './tsconfig';
 
 describe('tsconfig', () => {
@@ -31,9 +32,9 @@ describe('tsconfig', () => {
       bazelOptions: {},
     };
     const files = {
-      [path.resolve('path/to/user.tsconfig.json')]:
+      [normalizeSlashes(path.resolve('path/to/user.tsconfig.json'))]:
           '/*some comment*/\n' + JSON.stringify(userTsconfig),
-      [path.resolve('path/to/generated.tsconfig.json')]:
+      [normalizeSlashes(path.resolve('path/to/generated.tsconfig.json'))]:
           JSON.stringify(generatedTsconfig),
     };
     const host: ts.ParseConfigHost = {


### PR DESCRIPTION
Minimal `normalizeSlashes` needed to fix rules_typescript build & tests on Windows

/cc @alexeagle 