### PR TITLE
Example pulls nested file in genrule.

### DIFF
--- a/examples/bar.ts
+++ b/examples/bar.ts
@@ -17,6 +17,7 @@
 
 import {Greeter} from 'build_bazel_rules_typescript/examples/foo';
 import {a} from 'build_bazel_rules_typescript/examples/generated_ts/foo';
+import {b} from 'build_bazel_rules_typescript/examples/generated_ts/subdir/bar';
 // Repro for #31, should automatically discover @types/node
 import * as fs from 'fs';
 import {cool} from 'some-lib';
@@ -24,4 +25,4 @@ import * as ts from 'typescript';
 
 import {greeter} from './foo';
 
-console.log(Greeter, fs, cool, ts, greeter, a);
+console.log(Greeter, fs, cool, ts, greeter, a, b);

--- a/examples/generated_ts/BUILD.bazel
+++ b/examples/generated_ts/BUILD.bazel
@@ -8,7 +8,16 @@ genrule(
   cmd = "echo 'export const a = 1;' > $@",
 )
 
+genrule(
+  name = "nested_dir_ts",
+  outs = ["subdir/bar.ts"],
+  cmd = "echo 'export const b = 2;' > $@",
+)
+
 ts_library(
   name = "generated_ts",
-  srcs = [":foo.ts"],
+  srcs = [
+    ":foo.ts",
+    ":subdir/bar.ts",
+  ],
 )


### PR DESCRIPTION
Rules can make subdirs, add a demo of pulling a var from a rule that
makes subdirs.

I wrote this to validate a theory on a bug I was having. I was expecting
this to fail, but it didn't so I figured I'd just commit it and improve the
examples a little.