### PR TITLE
Add additional_root_paths to ts_devserver

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -26,8 +26,8 @@ platforms:
     build_targets:
     - "..."
     test_flags:
-    # TODO(gregmagolan): firefox unknown breakage on macos target here; does work locally on mac
-    - "--test_tag_filters=-browser:firefox-local"
+    # TODO(gregmagolan): chrome & firefox unknown breakage on macos target here; does work locally on mac
+    - "--test_tag_filters=-browser:chromium-local,-browser:firefox-local"
     test_targets:
     - "..."
   windows:

--- a/.ci/rules_typescript.json
+++ b/.ci/rules_typescript.json
@@ -14,7 +14,8 @@
             {"node": "darwin-x86_64"}
         ],
         "parameters": {
-            "configure": ["$BAZEL run @yarn//:yarn"]
+            "configure": ["$BAZEL run @yarn//:yarn"],
+            "test_tag_filters": ["-browser:chromium-local"]
         }
     }
 ]

--- a/internal/karma/ts_web_test.bzl
+++ b/internal/karma/ts_web_test.bzl
@@ -18,6 +18,8 @@ load("@build_bazel_rules_nodejs//internal:node.bzl",
     "expand_path_into_runfiles",
 )
 load("@build_bazel_rules_nodejs//internal/js_library:js_library.bzl", "write_amd_names_shim")
+load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
+load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
 
 _CONF_TMPL = "//internal/karma:karma.conf.js"
 
@@ -211,9 +213,6 @@ def ts_web_test_macro(tags = [], data = [], **kwargs):
       # FIXME: maybe we can just ask the attr._karma for its runfiles attr
       data = data + ["@build_bazel_rules_typescript//internal/karma:karma_bin"],
       **kwargs)
-
-load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
-load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
 
 def ts_web_test_suite(
   name,


### PR DESCRIPTION
Example usage of this feature is here https://github.com/gregmagolan/angular-bazel-example/tree/devserver-roots (commit https://github.com/gregmagolan/angular-bazel-example/commit/c90ccb344ff95ae61a4cf3e333539da957885b20)

Includes a fix in devserver.go which allows index.html to not have to be in the first root path