### PR TITLE
Exclude bootstrap and node_modules files from possible karma test files

### DIFF
--- a/internal/karma/karma.conf.js
+++ b/internal/karma/karma.conf.js
@@ -11,7 +11,8 @@ const tmp = require('tmp');
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 let files = [
-TMPL_files
+TMPL_bootstrap_files
+TMPL_user_files
 ];
 
 // On Windows, runfiles will not be in the runfiles folder but inteaad
@@ -45,7 +46,7 @@ var requireConfigContent = `
 // This does an explicit \`require\` on each test script in the files, otherwise nothing will be loaded.
 (function(){
   var allFiles = [
-TMPL_files
+TMPL_user_files
   ];
   var allTestFiles = [];
   allFiles.forEach(function (file) {

--- a/internal/karma/karma.conf.js
+++ b/internal/karma/karma.conf.js
@@ -11,7 +11,7 @@ const tmp = require('tmp');
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 let files = [
-  TMPL_files
+TMPL_files
 ];
 
 // On Windows, runfiles will not be in the runfiles folder but inteaad
@@ -42,12 +42,16 @@ if (fs.existsSync(manifestFile)) {
 
 var requireConfigContent = `
 // A simplified version of Karma's requirejs.config.tpl.js for use with Karma under Bazel.
-// This does an explicit \`require\` on each script in the files, otherwise nothing will be loaded.
+// This does an explicit \`require\` on each test script in the files, otherwise nothing will be loaded.
 (function(){
-  var allFiles = ${JSON.stringify([TMPL_files])};
+  var allFiles = [
+TMPL_files
+  ];
   var allTestFiles = [];
   allFiles.forEach(function (file) {
-    if (/(spec|test)\\.js$/i.test(file)) {
+    // test all files that end in spec.js or test.js but exclude
+    // any files from node_modules that match this pattern
+    if (/(spec|test)\\.js$/i.test(file) && !/\\/node_modules\\//.test(file)) {
       allTestFiles.push(file.replace(/\\.js$/, ''))
     }
   });

--- a/internal/karma/ts_web_test.bzl
+++ b/internal/karma/ts_web_test.bzl
@@ -41,10 +41,11 @@ def _ts_web_test_impl(ctx):
   # build_bazel_rules_typescript_karma_deps/node_modules/karma-jasmine/lib/boot.js
   # build_bazel_rules_typescript_karma_deps/node_modules/karma-jasmine/lib/adapter.js
   # This is desired so that the bootstrap entries can patch jasmine, as zone.js does.
-  files_entries = [
+  bootstrap_entries = [
       expand_path_into_runfiles(ctx, f.short_path)
       for f in ctx.files.bootstrap
   ]
+
   # Explicitly list the requirejs library files here, rather than use
   # `frameworks: ['requirejs']`
   # so that we control the script order, and the bootstrap files come before
@@ -52,12 +53,13 @@ def _ts_web_test_impl(ctx):
   # That allows bootstrap files to have anonymous AMD modules, or to do some
   # polyfilling before test libraries load.
   # See https://github.com/karma-runner/karma/issues/699
-  files_entries += [
+  bootstrap_entries += [
     "build_bazel_rules_typescript_karma_deps/node_modules/requirejs/require.js",
     "build_bazel_rules_typescript_karma_deps/node_modules/karma-requirejs/lib/adapter.js",
   ]
+
   # Finally we load the user's srcs and deps
-  files_entries += [
+  user_entries = [
       expand_path_into_runfiles(ctx, f.short_path)
       for f in files
   ]
@@ -70,7 +72,8 @@ def _ts_web_test_impl(ctx):
       template =  ctx.file._conf_tmpl,
       substitutions = {
           "TMPL_runfiles_path": "/".join([".."] * config_segments),
-          "TMPL_files": "\n".join(["      '%s'," % e for e in files_entries]),
+          "TMPL_bootstrap_files": "\n".join(["      '%s'," % e for e in bootstrap_entries]),
+          "TMPL_user_files": "\n".join(["      '%s'," % e for e in user_entries]),
           "TMPL_workspace_name": ctx.workspace_name,
           "TMPL_browser": _BROWSER,
           "TMPL_headlessbrowser": "%sHeadless" % _BROWSER,


### PR DESCRIPTION
@alexeagle This fixes ts_web_test failures in angular-bazel-example since some files from deps in node_modules that end in `test.js` are mistaken as test files to run.

Thinking about this, it seems fragile to look through all the `deps` of ts_web_test to find files that end in `test.js` and `spec.js` (what the original karma `requirejs.config.tpl.js` does). I think it would be more robust if ts_web_test had a separate attribute besides deps to specify the test files themselves. Maybe `test_deps` or `test_files`? Thoughts?