### PR TITLE
Remove puppeteer & turn on preserve-symlinks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,9 +16,9 @@ workspace(name = "build_bazel_rules_typescript")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/092404e3b47e1144ecfc2937d3729b717b1052bf.zip",
-    strip_prefix = "rules_nodejs-092404e3b47e1144ecfc2937d3729b717b1052bf",
-    sha256 = "5e3dd3f76a043687939a14ce6aee3049f8bd97d2cd885ef2105ac344d05213a3",
+    url = "https://github.com/bazelbuild/rules_nodejs/archive/0.8.0.zip",
+    strip_prefix = "rules_nodejs-0.8.0",
+    sha256 = "4e40dd49ae7668d245c3107645f2a138660fcfd975b9310b91eda13f0c973953",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
@@ -37,7 +37,9 @@ yarn_install(
 #   @build_bazel_rules_typescript_node//:bin/npm
 # - The yarn package manager:
 #   @yarn//:yarn
-node_repositories(package_json = ["//:package.json"])
+node_repositories(
+  package_json = ["//:package.json"],
+  preserve_symlinks = True)
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
 

--- a/internal/karma/BUILD.bazel
+++ b/internal/karma/BUILD.bazel
@@ -24,3 +24,8 @@ nodejs_binary(
     data = [":karma_concat_js"],
     node_modules = "@build_bazel_rules_typescript_karma_deps//:node_modules",
 )
+
+sh_binary(
+  name = "extract",
+  srcs = ["extract.sh"],
+)

--- a/internal/karma/browser_repository.bzl
+++ b/internal/karma/browser_repository.bzl
@@ -1,0 +1,50 @@
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Downloads browser files based on local platform."""
+
+def _impl(repository_ctx):
+  if repository_ctx.os.name.lower().startswith("mac os"):
+    urls = repository_ctx.attr.macos_urls
+    sha256 = repository_ctx.attr.macos_sha256
+  elif repository_ctx.os.name.lower().startswith("windows"):
+    urls = repository_ctx.attr.windows_urls
+    sha256 = repository_ctx.attr.windows_sha256
+  else:
+    urls = repository_ctx.attr.amd64_urls
+    sha256 = repository_ctx.attr.amd64_sha256
+  basename = urls[0][urls[0].rindex("/") + 1:]
+  repository_ctx.download(urls, basename, sha256)
+  repository_ctx.symlink(basename, "file/" + basename)
+  repository_ctx.file(
+      "file/BUILD", "\n".join([
+          ("# DO NOT EDIT: automatically generated BUILD file for " +
+           "browser_repository rule " + repository_ctx.name),
+          "filegroup(",
+          "    name = 'file',",
+          "    srcs = ['%s']," % basename,
+          "    visibility = ['//visibility:public'],",
+          ")",
+      ]))
+
+browser_repository = repository_rule(
+    implementation = _impl,
+    attrs = {
+        "amd64_urls": attr.string_list(),
+        "amd64_sha256": attr.string(),
+        "macos_urls": attr.string_list(),
+        "macos_sha256": attr.string(),
+        "windows_urls": attr.string_list(),
+        "windows_sha256": attr.string(),
+    },
+)

--- a/internal/karma/extract.sh
+++ b/internal/karma/extract.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+ARCHIVE=$1
+OUT_DIR=$2
+STRIP_PREFIX=$3
+
+mkdir -p "${OUT_DIR}"
+
+BASENAME=$(basename "${ARCHIVE}")
+
+if [[ "${BASENAME}" == *.deb ]]; then
+  dpkg -x "${ARCHIVE}" "${OUT_DIR}"
+elif [[ "${BASENAME}" == *.tar ]]; then
+  tar xf "${ARCHIVE}" -C "${OUT_DIR}"
+elif [[ "${BASENAME}" == *.tar.bz2 || "${BASENAME}" == *.tbz2 ]]; then
+  tar xjf "${ARCHIVE}" -C "${OUT_DIR}"
+elif [[ "${BASENAME}" == *.tar.gz || "${BASENAME}" == *.tgz ]]; then
+  tar xzf "${ARCHIVE}" -C "${OUT_DIR}"
+elif [[ "${BASENAME}" == *.tar.Z ]]; then
+  tar xZf "${ARCHIVE}" -C "${OUT_DIR}"
+elif [[ "${BASENAME}" == *.zip ]]; then
+  unzip "${ARCHIVE}" -d "${OUT_DIR}"
+else
+  exit -1
+fi
+
+if [[ ! -z "${STRIP_PREFIX}" ]]; then
+  pushd "${OUT_DIR}"
+  # Intentionally not quoted so that globbing in STRIP_PREFIX works.
+  mv ${STRIP_PREFIX}/* .
+  popd
+fi

--- a/internal/karma/karma.conf.js
+++ b/internal/karma/karma.conf.js
@@ -3,12 +3,22 @@
 const path = require('path');
 const fs = require('fs');
 const tmp = require('tmp');
+const os = require('os');
 
 // When karma is configured to use Chrome it will look for a CHROME_BIN
-// environment variable. This line points Karma to use puppeteer instead.
-// See
+// environment variable.
 // https://github.com/karma-runner/karma-chrome-launcher/blob/master/README.md#headless-chromium-with-puppeteer
-process.env.CHROME_BIN = require('puppeteer').executablePath();
+const chromeBinBase = 'TMPL_chrome_bin_base';
+const chromeBinPlatform = TMPL_chrome_bin_platform;
+const platform = os.platform();
+if (platform === 'darwin')
+  process.env.CHROME_BIN = path.join(chromeBinBase, chromeBinPlatform['darwin_amd64'])
+else if (platform === 'linux')
+  process.env.CHROME_BIN = path.join(chromeBinBase, chromeBinPlatform['linux_amd64'])
+else if (platform === 'win32')
+  process.env.CHROME_BIN = path.join(chromeBinBase, chromeBinPlatform['windows_amd64'])
+else
+  throw new Error(`Unknown platform ${platform}`);
 
 let files = [
   TMPL_bootstrap_files

--- a/internal/karma/package.json
+++ b/internal/karma/package.json
@@ -7,7 +7,6 @@
     "karma-jasmine": "1.1.1",
     "karma-sourcemap-loader": "0.3.7",
     "karma-requirejs": "1.1.0",
-    "puppeteer": "1.1.0",
     "requirejs": "2.3.5",
     "tmp": "0.0.33"
   }

--- a/internal/karma/yarn.lock
+++ b/internal/karma/yarn.lock
@@ -28,12 +28,6 @@ agent-base@2:
     extend "~3.0.0"
     semver "~5.0.1"
 
-agent-base@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
-  dependencies:
-    es6-promisify "^5.0.0"
-
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -381,14 +375,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
 connect@^3.6.0:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/connect/-/connect-3.6.5.tgz#fb8dde7ba0763877d0ec9df9dac0b4b40e72c7da"
@@ -448,7 +434,7 @@ date-format@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-1.2.0.tgz#615e828e233dd1ab9bb9ae0950e0ceccfa6ecad8"
 
-debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.6.8, debug@~2.6.4, debug@~2.6.6, debug@~2.6.9:
+debug@2, debug@2.6.9, debug@^2.2.0, debug@~2.6.4, debug@~2.6.6, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -576,16 +562,6 @@ ent@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
 
-es6-promise@^4.0.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  dependencies:
-    es6-promise "^4.0.3"
-
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -658,15 +634,6 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extract-zip@^1.6.5:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
-  dependencies:
-    concat-stream "1.6.0"
-    debug "2.6.9"
-    mkdirp "0.5.0"
-    yauzl "2.4.1"
-
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -686,12 +653,6 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-
-fd-slicer@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
-  dependencies:
-    pend "~1.2.0"
 
 file-uri-to-path@1:
   version "1.0.0"
@@ -1019,13 +980,6 @@ https-proxy-agent@1:
     debug "2"
     extend "3"
 
-https-proxy-agent@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
-  dependencies:
-    agent-base "^4.1.0"
-    debug "^3.1.0"
-
 iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
@@ -1053,7 +1007,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1432,12 +1386,6 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
-
 "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -1686,10 +1634,6 @@ path-proxy@~1.0.0:
   dependencies:
     inflection "~1.3.0"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -1720,14 +1664,6 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-process-nextick-args@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
-
-progress@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
-
 proxy-agent@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-2.0.0.tgz#57eb5347aa805d74ec681cb25649dba39c933499"
@@ -1741,10 +1677,6 @@ proxy-agent@~2.0.0:
     pac-proxy-agent "1"
     socks-proxy-agent "2"
 
-proxy-from-env@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
-
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -1752,19 +1684,6 @@ pseudomap@^1.0.2:
 punycode@1.4.1, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-puppeteer@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.1.0.tgz#97fbc2fbbf9ab659e7e202a68ac1ba54b8bc0a25"
-  dependencies:
-    debug "^2.6.8"
-    extract-zip "^1.6.5"
-    https-proxy-agent "^2.1.0"
-    mime "^1.3.4"
-    progress "^2.0.0"
-    proxy-from-env "^1.0.0"
-    rimraf "^2.6.1"
-    ws "^3.0.0"
 
 q@~1.4.0:
   version "1.4.1"
@@ -1832,18 +1751,6 @@ readable-stream@2, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stre
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.2.2:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
@@ -2280,10 +2187,6 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typedarray@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
@@ -2363,7 +2266,7 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-ws@^3.0.0, ws@~3.3.1:
+ws@~3.3.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
   dependencies:
@@ -2386,12 +2289,6 @@ xtend@^4.0.0:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-
-yauzl@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
-  dependencies:
-    fd-slicer "~1.0.1"
 
 yeast@0.1.2:
   version "0.1.2"

--- a/internal/ts_repositories.bzl
+++ b/internal/ts_repositories.bzl
@@ -15,6 +15,7 @@
 "Install toolchain dependencies"
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
+load("//internal/karma:browser_repository.bzl", "browser_repository")
 
 def ts_setup_workspace():
   """This repository rule should be called from your WORKSPACE file.
@@ -44,3 +45,18 @@ def ts_setup_workspace():
       package_json = "@build_bazel_rules_typescript//internal/protobufjs:package.json",
       yarn_lock = "@build_bazel_rules_typescript//internal/protobufjs:yarn.lock",
   )
+
+  browser_repository(
+      name="build_bazel_rules_typescript_chromium",
+      amd64_sha256="51a189382cb5272d240a729da0ae77d0211c1bbc0d10b701a2723b5b068c1e3a",
+      amd64_urls=[
+          "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/539259/chrome-linux.zip"
+      ],
+      macos_sha256="866ec9aa4e07cc86ae1d5aeb6e9bdafb5f94989c7c0be661302930ad667f41f3",
+      macos_urls=[
+          "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/539251/chrome-mac.zip"
+      ],
+      windows_sha256="be4fcc7257d85c12ae2de10aef0150ddbb7b9ecbd5ada6a898d247cf867a058a",
+      windows_urls=[
+          "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/539249/chrome-win32.zip"
+      ])


### PR DESCRIPTION
Removed dependency on puppeteer which was breaking preserve-symlinks since Chrome was downloaded into node_modules with invalid file names.

Platform dependent chromium archive is now downloaded via repository rule. ts_webtest unzips this file and uses this chrome to run the webtest.

--preserve-symlinks is also turned on for the repository.