### PR TITLE
Add static_files attribute to ts_web_test & ts_web_test_suite

### DIFF
--- a/examples/testing/BUILD.bazel
+++ b/examples/testing/BUILD.bazel
@@ -7,8 +7,9 @@ ts_library(
 
 ts_library(
     name = "tests",
-    srcs = ["decrement.spec.ts"],
+    srcs = glob(["*.spec.ts"]),
     deps = [":lib"],
+    tsconfig = ":tsconfig.json",
     testonly = 1,
 )
 
@@ -16,6 +17,9 @@ ts_web_test_suite(
     name = "testing",
     deps = [
       ":tests",
+    ],
+    static_files = [
+      "static_script.js",
     ],
     browsers = [
       "@io_bazel_rules_webtesting//browsers:chromium-local",

--- a/examples/testing/static_script.js
+++ b/examples/testing/static_script.js
@@ -1,0 +1,1 @@
+window.someGlobal = "someGlobal";

--- a/examples/testing/static_script.spec.ts
+++ b/examples/testing/static_script.spec.ts
@@ -1,0 +1,20 @@
+const someGlobal = new Promise<string>((resolve, reject) => {
+  const script = document.createElement('script');
+  script.src = `base/build_bazel_rules_typescript/examples/testing/static_script.js`;
+  script.onerror = reject;
+  script.onload = () => {
+    document.body.removeChild(script);
+    resolve((window as any).someGlobal);
+  };
+  document.body.appendChild(script);
+});
+
+describe('static script', () => {
+  it('should load', async () => {
+    expect(await someGlobal).toBe("someGlobal");
+  });
+});
+
+// at least one import or export is needed for this file to
+// be compiled into an named-UMD module by typescript
+export const someValue = "someValue";

--- a/examples/testing/tsconfig.json
+++ b/examples/testing/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["es2015.promise", "dom", "es5"],
+  }
+}
+

--- a/internal/karma/karma.conf.js
+++ b/internal/karma/karma.conf.js
@@ -26,36 +26,54 @@ if (!browsers.length) {
   browsers.push(process.env['DISPLAY'] ? 'Chrome': 'ChromeHeadless');
 }
 
-let files = [
-  TMPL_bootstrap_files
-  TMPL_user_files
-];
-
 // On Windows, runfiles will not be in the runfiles folder but inteaad
 // there is a MANIFEST file which maps the runfiles for the test
 // to their location on disk. Bazel provides a TEST_SRCDIR environment
 // variable which is set to the runfiles folder during test execution.
 // If a MANIFEST file is found, we remap the test files to their
 // location on disk using the MANIFEST file.
+let manifest = null;
 const manifestFile = path.join(process.env.TEST_SRCDIR || '', 'MANIFEST');
 if (fs.existsSync(manifestFile)) {
   // MANIFEST file contains the one runfile mapping per line seperated
   // a space. For example:
   // rxjs/operators.js /private/var/tmp/.../external/rxjs/operators.js
   // The file is parsed here into a map of for easy lookup
-  const manifest = {};
+  manifest = {};
   for (l of fs.readFileSync(manifestFile, 'utf8').split('\n')) {
     const m = l.split(' ');
     manifest[m[0]] = m[1];
   }
-  files = files.map(f => {
-    const manifestFile = manifest[f];
-    if (!manifestFile) {
-      throw new Error(`File not found in MANIFEST: ${f}`);
-    }
-    return manifestFile;
-  });
 }
+
+function resolveRunfiles(manifest, runfiles) {
+  if (manifest) {
+    runfiles = runfiles.map(f => {
+      const manifestFile = manifest[f];
+      if (!manifestFile) {
+        throw new Error(`File not found in MANIFEST: ${f}`);
+      }
+      return manifestFile;
+    });
+  }
+  return runfiles;
+}
+
+let files = resolveRunfiles(manifest, [
+  TMPL_bootstrap_files
+  TMPL_user_files
+]);
+
+// static files are added to the files array but
+// configured to not be included so karma-concat-js does
+// not included them in the bundle
+const staticFiles = resolveRunfiles(manifest, [
+  TMPL_static_files
+]);
+
+staticFiles.forEach(f => {
+  files.push({ pattern: f, included: false });
+});
 
 var requireConfigContent = `
 // A simplified version of Karma's requirejs.config.tpl.js for use with Karma under Bazel.

--- a/internal/karma/ts_web_test.bzl
+++ b/internal/karma/ts_web_test.bzl
@@ -69,6 +69,10 @@ def _ts_web_test_impl(ctx):
       expand_path_into_runfiles(ctx, f.short_path)
       for f in files
   ]
+  static_files = [
+      expand_path_into_runfiles(ctx, f.short_path)
+      for f in ctx.files.static_files
+  ] 
 
   # root-relative (runfiles) path to the directory containing karma.conf
   config_segments = len(conf.short_path.split("/"))
@@ -80,12 +84,22 @@ def _ts_web_test_impl(ctx):
           "TMPL_runfiles_path": "/".join([".."] * config_segments),
           "TMPL_bootstrap_files": "\n".join(["      '%s'," % e for e in bootstrap_entries]),
           "TMPL_user_files": "\n".join(["      '%s'," % e for e in user_entries]),
+          "TMPL_static_files": "\n".join(["      '%s'," % e for e in static_files]),
           "TMPL_workspace_name": ctx.workspace_name,
       })
 
   karma_executable_path = ctx.executable._karma.short_path
   if karma_executable_path.startswith('..'):
     karma_executable_path = "external" + karma_executable_path[2:]
+
+  karma_runfiles = [
+    conf,
+    amd_names_shim,
+  ]
+  karma_runfiles += ctx.files.srcs
+  karma_runfiles += ctx.files.deps
+  karma_runfiles += ctx.files.bootstrap
+  karma_runfiles += ctx.files.static_files
 
   ctx.actions.write(
       output = ctx.outputs.executable,
@@ -121,9 +135,7 @@ $KARMA ${{ARGV[@]}}
   return [DefaultInfo(
       files = depset([ctx.outputs.executable]),
       runfiles = ctx.runfiles(
-          files = ctx.files.srcs + ctx.files.deps + ctx.files.bootstrap + [
-              conf, amd_names_shim
-          ],
+          files = karma_runfiles,
           transitive_files = files,
           # Propagate karma_bin and its runfiles
           collect_data = True,
@@ -154,6 +166,9 @@ ts_web_test = rule(
         "data": attr.label_list(
             doc = "Runtime dependencies",
             cfg = "data"),
+        "static_files": attr.label_list(
+            doc = """Arbitrary files which to be served.""",
+            allow_files = True),
         "_karma": attr.label(
             default = Label("//internal/karma:karma_bin"),
             executable = True,


### PR DESCRIPTION
Allows re-enabling `packages/upgrade/test:test_web` test in angular/angular: https://github.com/gregmagolan/angular/tree/ts-web-test-static-files (based off of https://github.com/angular/angular/pull/23845)