### PR TITLE
Replace deprecated `library` with `embed` in go_test

### DIFF
--- a/internal/concatjs/BUILD
+++ b/internal/concatjs/BUILD
@@ -21,5 +21,5 @@ go_test(
     importpath = "do_not_import",
     size = "small",
     srcs = ["concatjs_test.go"],
-    library = ":concatjs",
+    embed = [":concatjs"],
 )

--- a/internal/devserver/BUILD
+++ b/internal/devserver/BUILD
@@ -42,7 +42,7 @@ go_test(
     name = "devserver_test",
     size = "small",
     srcs = ["devserver_test.go"],
-    library = ":devserver",
+    embed = [":devserver"],
     # See https://github.com/bazelbuild/rules_go/issues/721
     importpath = "do_not_import",
 )


### PR DESCRIPTION
`library` attribute is deprecated in `go_test`:
```
DEPRECATED: //internal/devserver:devserver_test : the library attribute on go_test is deprecated. Please migrate to embed.
```
In rules_go v.0.12.0 it's causing an error:
```
(18:04:54) ERROR: /home/alex/.cache/bazel/_bazel_alex/9def434882dfecce7f21cdef6844c099/external/build_bazel_rules_typescript/internal/concatjs/BUILD:18:1: @build_bazel_rules_typescript//internal/concatjs:concatjs_test: no such attribute 'library' in 'go_test' rule
```