### PR TITLE
Use module=esnext for production mode output

### DIFF
--- a/examples/bar.ts
+++ b/examples/bar.ts
@@ -22,6 +22,6 @@ import * as fs from 'fs';
 import {cool} from 'some-lib';
 import * as ts from 'typescript';
 
-import {greeter} from './foo';
-
-console.log(Greeter, fs, cool, ts, greeter, a);
+import('./foo').then(({greeter}) => {
+  console.log(Greeter, fs, cool, ts, greeter, a);
+});

--- a/examples/es6_output/es6_output_test.sh
+++ b/examples/es6_output/es6_output_test.sh
@@ -9,10 +9,18 @@ if [[ "$FOO_JS" != *"class Greeter"* ]]; then
   exit 1
 fi
 
-# should not down-level ES2015 syntax, eg. `class`
+# should not down-level ES Modules
 readonly LIBRARY_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/es6_output.es6/examples/some_library/library.js)
 if [[ "$LIBRARY_JS" != *"export const cool = 1;"* ]]; then
   echo "Expected library.js to contain 'export const cool = 1;' but was"
   echo "$LIBRARY_JS"
+  exit 1
+fi
+
+# should not down-level dynamic import
+readonly BAR_JS=$(cat $TEST_SRCDIR/build_bazel_rules_typescript/examples/es6_output/es6_output.es6/examples/bar.js)
+if [[ "$BAR_JS" != *"import('./foo')"* ]]; then
+  echo "Expected bar.js to contain 'import('./foo')' but was"
+  echo "$BAR_JS"
   exit 1
 fi

--- a/internal/common/tsconfig.bzl
+++ b/internal/common/tsconfig.bzl
@@ -166,13 +166,11 @@ def create_tsconfig(ctx, files, srcs,
       # The "typescript.es5_sources" provider is expected to work
       # in both nodejs and in browsers, so we use umd in devmode.
       # NOTE: tsc-wrapped will always name the enclosed AMD modules
-      # For production mode, we leave the module syntax at ES2015 and let the
-      # bundler handle it.
-      # TODO(alexeagle): production mode should use "esnext" allowing the bundler
-      # to see dynamic import statements.
+      # For production mode, we leave the module syntax alone and let the
+      # bundler handle it (including dynamic import).
       # Note, in google3 we override this option with "commonjs" since Tsickle
       # will convert that to goog.module syntax.
-      "module": "umd" if devmode_manifest or ctx.attr.runtime == "nodejs" else "es2015",
+      "module": "umd" if devmode_manifest or ctx.attr.runtime == "nodejs" else "esnext",
 
       # Has no effect in closure/ES2015 mode. Always true just for simplicity.
       "downlevelIteration": True,


### PR DESCRIPTION
This will be needed when a ts_library is in the deps of a webpack_bundle,
so that it understands lazy dependency edges from the JS source it sees.