### PR TITLE
nodejs_binaries tsc and tsc_wrapped_bin should not depend on @build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules

### DIFF
--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -30,7 +30,6 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "jasmine_node_test
 nodejs_binary(
     name = "tsc",
     entry_point = "typescript/lib/tsc.js",
-    node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
     visibility = ["//internal:__subpackages__"],
 )
 
@@ -72,7 +71,6 @@ nodejs_binary(
         ":tsc_wrapped",
     ],
     entry_point = "build_bazel_rules_typescript/internal/tsc_wrapped/tsc_wrapped.js",
-    node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
     templated_args = ["--node_options=--expose-gc"],
     visibility = ["//visibility:public"],
 )

--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -42,7 +42,7 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description 
 
     action_inputs = inputs + [
         f
-        for f in ctx.files.node_modules + ctx.files._tsc_wrapped_deps
+        for f in ctx.files.node_modules
         if f.path.endswith(".js") or f.path.endswith(".ts") or f.path.endswith(".json")
     ]
     if ctx.file.tsconfig:
@@ -201,7 +201,6 @@ ts_library = rule(
         ),
         "tsickle_typed": attr.bool(default = True),
         "internal_testing_type_check_dependencies": attr.bool(default = False, doc = "Testing only, whether to type check inputs that aren't srcs."),
-        "_tsc_wrapped_deps": attr.label(default = Label("@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules")),
         # @// is special syntax for the "main" repository
         # The default assumes the user specified a target "node_modules" in their
         # root BUILD file.

--- a/internal/ts_repositories.bzl
+++ b/internal/ts_repositories.bzl
@@ -32,6 +32,7 @@ def ts_setup_workspace():
         package_json = "@build_bazel_rules_typescript//internal:tsc_wrapped/package.json",
         yarn_lock = "@build_bazel_rules_typescript//internal:tsc_wrapped/yarn.lock",
     )
+
     yarn_install(
         name = "build_bazel_rules_typescript_devserver_deps",
         package_json = "@build_bazel_rules_typescript//internal/devserver:package.json",


### PR DESCRIPTION
These binaries should depend on the default user's `@//:node_modules` version of typescript