### PR TITLE
_compile_action: use the default shell environment when calling `ctx.action()`

### DIFF
--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -69,6 +69,7 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description 
         mnemonic = mnemonic,
         inputs = action_inputs,
         outputs = action_outputs,
+        use_default_shell_env = True,
         arguments = arguments,
         executable = ctx.executable.compiler,
         execution_requirements = {


### PR DESCRIPTION
NixOS does not provide an FHS, so the [bazel derivation](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/build-managers/bazel/default.nix) provides a default shell that's able to call other binaries such as `tr` and `uname`.

However, when `rules_typescript` invokes `tsc_wrapped`, it does not use the default shell and so it fails to find the aforementioned commands. This PR sets `use_default_shell_env` to True.

Please see https://github.com/NixOS/nixpkgs/issues/43955#issuecomment-407546331 for more details.