### PR TITLE
fix: amd module names inconsistent in windows

### DIFF
--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -7,6 +7,7 @@ import {FileLoader} from './file_cache';
 import * as perfTrace from './perf_trace';
 import {BazelOptions} from './tsconfig';
 import {DEBUG, debug} from './worker';
+import {convertToPosixPath} from './posix-paths';
 
 export type ModuleResolver =
     (moduleName: string, containingFile: string,
@@ -205,8 +206,9 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
     for (const root of this.options.rootDirs) {
       if (fileName.startsWith(root)) {
         // rootDirs are sorted longest-first, so short-circuit the iteration
-        // see tsconfig.ts.
-        return path.posix.relative(root, fileName);
+        // see tsconfig.ts. Since the fileName can already include multiple path segments with
+        // backslash delimiters, we need to manually convert the path to posix format.
+        return convertToPosixPath(path.relative(root, fileName));
       }
     }
     return fileName;

--- a/internal/tsc_wrapped/posix-paths.ts
+++ b/internal/tsc_wrapped/posix-paths.ts
@@ -1,0 +1,21 @@
+import {resolve} from 'path';
+
+/**
+ * Converts a path which could potentially include backslash delimiters into a consistent posix
+ * path that uses forward slashes.
+ * 
+ * Note that path.posix.resolve('a\\b\\c') still returns a non-posix path with backslashes.
+ */
+export function convertToPosixPath(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+/**
+ * The same as Node's path.resolve, however it returns a path with forward
+ * slashes rather than joining the resolved path with the platform's path
+ * separator.
+ * Note that even path.posix.resolve('.') returns C:\Users\... with backslashes.
+ */
+export function resolveNormalizedPath(...segments: string[]): string {
+  return convertToPosixPath(resolve(...segments));
+}

--- a/internal/tsc_wrapped/tsc_wrapped.ts
+++ b/internal/tsc_wrapped/tsc_wrapped.ts
@@ -7,8 +7,9 @@ import {CompilerHost} from './compiler_host';
 import * as diagnostics from './diagnostics';
 import {CachedFileLoader, FileCache, FileLoader, UncachedFileLoader} from './file_cache';
 import {wrap} from './perf_trace';
+import {resolveNormalizedPath} from './posix-paths';
 import {PLUGIN as strictDepsPlugin} from './strict_deps';
-import {BazelOptions, parseTsconfig, resolveNormalizedPath} from './tsconfig';
+import {BazelOptions, parseTsconfig} from './tsconfig';
 import {fixUmdModuleDeclarations} from './umd_module_declaration_transform';
 import {debug, log, runAsWorker, runWorkerLoop} from './worker';
 

--- a/internal/tsc_wrapped/tsconfig.ts
+++ b/internal/tsc_wrapped/tsconfig.ts
@@ -17,6 +17,7 @@
 
 import * as path from 'path';
 import * as ts from 'typescript';
+import {resolveNormalizedPath} from './posix-paths';
 
 /**
  * The configuration block provided by the tsconfig "bazelOptions".
@@ -230,16 +231,6 @@ function warnOnOverriddenOptions(userConfig: any) {
     for (const w of overrideWarnings) console.error(` - ${w}`);
     console.error('\n');
   }
-}
-
-/**
- * The same as Node's path.resolve, however it returns a path with forward
- * slashes rather than joining the resolved path with the platform's path
- * separator.
- * Note that even path.posix.resolve('.') returns C:\Users\... with backslashes.
- */
-export function resolveNormalizedPath(...segments: string[]): string {
-  return path.resolve(...segments).replace(/\\/g, '/');
 }
 
 /**

--- a/internal/tsc_wrapped/tsconfig_test.ts
+++ b/internal/tsc_wrapped/tsconfig_test.ts
@@ -16,8 +16,8 @@
  */
 
 import * as ts from 'typescript';
-
-import {parseTsconfig, resolveNormalizedPath} from './tsconfig';
+import {resolveNormalizedPath} from './posix-paths';
+import {parseTsconfig} from './tsconfig';
 
 describe('tsconfig', () => {
   it('honors bazelOptions in the users tsconfig', () => {


### PR DESCRIPTION
* Currently when building a `ts_library` within Windows, the AMD module name includes backslash delimiters. For consistency, the amd module names should always use posix paths.

cc. @alexeagle 