### PR TITLE
Generate BUILD.bazel files before running tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,6 +2,7 @@
 platforms:
   ubuntu1404:
     run_targets:
+    - "//:gazelle"
     - "@nodejs//:yarn"
     build_targets:
     - "..."
@@ -12,6 +13,7 @@ platforms:
     - "..."
   ubuntu1604:
     run_targets:
+    - "//:gazelle"
     - "@nodejs//:yarn"
     build_targets:
     - "..."
@@ -22,6 +24,7 @@ platforms:
     - "..."
   macos:
     run_targets:
+    - "//:gazelle"
     - "@nodejs//:yarn"
     build_targets:
     - "..."
@@ -32,6 +35,7 @@ platforms:
     - "..."
   windows:
     run_targets:
+    - "//:gazelle"
     - "@nodejs//:yarn"
     # TODO(alexeagle): expand to all targets when rules_go is fixed
     build_targets:


### PR DESCRIPTION
This should generate all the necessary files by running the "//:gazelle" target before testing anything.