### PR TITLE
Bump bazel go dependencies

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -25,7 +25,7 @@ build --experimental_repository_cache=/home/circleci/bazel_repository_cache
 
 # Workaround https://github.com/bazelbuild/bazel/issues/3645
 # Bazel doesn't calculate the memory ceiling correctly when running under Docker.
-# Limit Bazel to consuming 3072M of RAM
-build --local_resources=3072,2.0,1.0
+# Limit Bazel to consuming 2560K of RAM
+build --local_resources=2560,1.0,1.0
 # Also limit Bazel's own JVM heap to stay within our 4G container limit
-startup --host_jvm_args=-Xmx2G
+startup --host_jvm_args=-Xmx1g

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@
 
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix
-var_1: &docker_image angular/ngcontainer:0.3.3
-var_2: &cache_key rules_typescript-{{ checksum "yarn.lock" }}-0.3.3
+var_1: &docker_image angular/ngcontainer:0.4.0
+var_2: &cache_key rules_typescript-{{ checksum "yarn.lock" }}-0.4.0
 var_3: &setup-bazel-remote-cache
   run:
     name: Start up bazel remote cache proxy

--- a/README.md
+++ b/README.md
@@ -54,20 +54,24 @@ http_archive(
 # ts_web_test depends on the web testing rules to provision browsers.
 http_archive(
     name = "io_bazel_rules_webtesting",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/archive/v0.2.0.zip"],
-    strip_prefix = "rules_webtesting-0.2.0",
-    sha256 = "cecc12f07e95740750a40d38e8b14b76fefa1551bef9332cb432d564d693723c",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/archive/0.2.1.zip"],
+    strip_prefix = "rules_webtesting-0.2.1",
+    sha256 = "7d490aadff9b5262e5251fa69427ab2ffd1548422467cb9f9e1d110e2c36f0fa",
 )
 
 # ts_devserver depends on the Go rules.
 # See https://github.com/bazelbuild/rules_go#setup for the latest version.
 http_archive(
     name = "io_bazel_rules_go",
-    urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz"
-    ],
-    sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
+    sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
+)
+
+# go_repository is defined in bazel_gazelle
+http_archive(
+    name = "bazel_gazelle",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.13.0/bazel-gazelle-0.13.0.tar.gz"],
+    sha256 = "bc653d3e058964a5a26dcad02b6c72d7d63e6bb88d94704990b908a1445b8758",
 )
 
 # Include @bazel/typescript in package.json#devDependencies

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,11 +52,8 @@ node_repositories(
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz"
-    ],
-    sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
+    sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
 )
 
 http_archive(
@@ -67,8 +64,8 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.10.1/bazel-gazelle-0.10.1.tar.gz"],
-    sha256 = "d03625db67e9fb0905bbd206fa97e32ae9da894fe234a493e7517fd25faec914",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.13.0/bazel-gazelle-0.13.0.tar.gz"],
+    sha256 = "bc653d3e058964a5a26dcad02b6c72d7d63e6bb88d94704990b908a1445b8758",
 )
 
 BAZEL_BUILDTOOLS_VERSION = "0.12.0"
@@ -92,9 +89,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "io_bazel_rules_webtesting",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/archive/v0.2.0.zip"],
-    strip_prefix = "rules_webtesting-0.2.0",
-    sha256 = "cecc12f07e95740750a40d38e8b14b76fefa1551bef9332cb432d564d693723c",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/archive/0.2.1.zip"],
+    strip_prefix = "rules_webtesting-0.2.1",
+    sha256 = "7d490aadff9b5262e5251fa69427ab2ffd1548422467cb9f9e1d110e2c36f0fa",
 )
 
 load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories", "web_test_repositories")
@@ -130,6 +127,7 @@ http_archive(
     name = "io_bazel_skydoc",
     urls = ["https://github.com/bazelbuild/skydoc/archive/0ef7695c9d70084946a3e99b89ad5a99ede79580.zip"],
     strip_prefix = "skydoc-0ef7695c9d70084946a3e99b89ad5a99ede79580",
+    sha256 = "491f9e142b870b18a0ec8eb3d66636eeceabe5f0c73025706c86f91a1a2acb4d",
 )
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 skydoc_repositories()

--- a/internal/e2e/default_tsconfig_test.js
+++ b/internal/e2e/default_tsconfig_test.js
@@ -42,17 +42,19 @@ http_archive(
 )
 http_archive(
     name = "io_bazel_rules_webtesting",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/archive/v0.2.0.zip"],
-    strip_prefix = "rules_webtesting-0.2.0",
-    sha256 = "cecc12f07e95740750a40d38e8b14b76fefa1551bef9332cb432d564d693723c",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/archive/0.2.1.zip"],
+    strip_prefix = "rules_webtesting-0.2.1",
+    sha256 = "7d490aadff9b5262e5251fa69427ab2ffd1548422467cb9f9e1d110e2c36f0fa",
 )
 http_archive(
     name = "io_bazel_rules_go",
-    urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz"
-    ],
-    sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
+    sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
+)
+http_archive(
+    name = "bazel_gazelle",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.13.0/bazel-gazelle-0.13.0.tar.gz"],
+    sha256 = "bc653d3e058964a5a26dcad02b6c72d7d63e6bb88d94704990b908a1445b8758",
 )
 local_repository(
     name = "build_bazel_rules_typescript",

--- a/internal/ts_repositories.bzl
+++ b/internal/ts_repositories.bzl
@@ -15,7 +15,7 @@
 "Install toolchain dependencies"
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "check_rules_nodejs_version", "yarn_install")
-load("@io_bazel_rules_go//go:def.bzl", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 def ts_setup_workspace():
     """This repository rule should be called from your WORKSPACE file.


### PR DESCRIPTION
`go_repository` has been removed from `io_bazel_rules_go` as of rules_go 0.13.0 (https://github.com/bazelbuild/rules_go/releases/tag/0.13.0). Should now be loaded from `@bazel_gazelle//:deps.bzl`

Also updated to rules_webtesting 0.2.1 which correctly loads `go_repository` from `@bazel_gazelle//:deps.bzl`.