### PR TITLE
Allow users to disable auto quoting in tsickle

### DIFF
--- a/examples/googmodule/a.ts
+++ b/examples/googmodule/a.ts
@@ -1,1 +1,6 @@
 export const a: number = 1;
+interface Quoted {
+  [k: string]: number;
+}
+let quoted: Quoted = {};
+quoted.hello = a;

--- a/examples/googmodule/googmodule_output_test.js
+++ b/examples/googmodule/googmodule_output_test.js
@@ -3,18 +3,18 @@ const fs = require('fs');
 describe('googmodule', () => {
   let output;
   beforeAll(() => {
-    output = require.resolve(
-        'build_bazel_rules_typescript/examples/googmodule/a.js');
+    output = fs.readFileSync(require.resolve(
+        'build_bazel_rules_typescript/examples/googmodule/a.js'), 'utf-8');
   });
 
   it('should have goog module syntax in devmode', () => {
-    expect(fs.readFileSync(output, {encoding: 'utf-8'}))
-        .toContain(
-            `goog.module('build_bazel_rules_typescript.examples.googmodule.a')`);
+    expect(output).toContain(
+        `goog.module('build_bazel_rules_typescript.examples.googmodule.a')`);
   });
   it('should have tsickle type annotations', () => {
-    expect(fs.readFileSync(output, {
-      encoding: 'utf-8'
-    })).toContain(`@type {number}`);
+    expect(output).toContain(`@type {number}`);
+  });
+  it('should not auto-quote properties', () => {
+    expect(output).not.toContain(`quoted["hello"]`);
   });
 });

--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -82,7 +82,6 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
   isJsTranspilation: boolean;
   provideExternalModuleDtsNamespace: boolean;
   options: BazelTsOptions;
-  disableAutoQuoting?: boolean = true;
   host: ts.ModuleResolutionHost = this;
 
   constructor(

--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -82,6 +82,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
   isJsTranspilation: boolean;
   provideExternalModuleDtsNamespace: boolean;
   options: BazelTsOptions;
+  disableAutoQuoting?: boolean = true;
   host: ts.ModuleResolutionHost = this;
 
   constructor(

--- a/internal/tsc_wrapped/tsc_wrapped.ts
+++ b/internal/tsc_wrapped/tsc_wrapped.ts
@@ -159,6 +159,13 @@ function runOneBuild(
           'When setting bazelOpts { tsickle: true }, ' +
           'you must also add a devDependency on the tsickle npm package');
     }
+
+    // Turn off tsickle's auto-quoting feature for Bazel users.
+    // It causes problems (https://github.com/angular/tsickle/issues/683)
+    // We don't know of any Bazel TS users who want this feature, so rather than
+    // make it user-configurable, we disable it globally under tsc_wrapped.
+    (compilerHost as tsickle.TsickleHost).disableAutoQuoting = true;
+
     for (const sf of toEmit) {
       emitResults.push(optTsickle.emitWithTsickle(
           program, compilerHost, compilerHost, options, sf,


### PR DESCRIPTION
tsickle's auto-quoting feature sometimes causes unexpected behavior (see https://github.com/angular/tsickle/issues/683). tsickle accepts a flag to disable this feature, and this PR exposes that flag to the user.