### PR TITLE
Change deprecated Bazel single file attr param

### DIFF
--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -191,8 +191,7 @@ ts_library = rule(
               `alias(name="tsconfig.json", actual="//path/to:tsconfig-something.json")`
             - Give an explicit `tsconfig` attribute to all `ts_library` targets
             """,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "compiler": attr.label(
             doc = """Intended for internal use only.

--- a/internal/devserver/ts_devserver.bzl
+++ b/internal/devserver/ts_devserver.bzl
@@ -162,7 +162,7 @@ ts_devserver = rule(
             doc = """The port that the devserver will listen on.""",
             default = 5432,
         ),
-        "_requirejs_script": attr.label(allow_files = True, single_file = True, default = Label("@build_bazel_rules_typescript_devserver_deps//:node_modules/requirejs/require.js")),
+        "_requirejs_script": attr.label(allow_single_file = True, default = Label("@build_bazel_rules_typescript_devserver_deps//:node_modules/requirejs/require.js")),
         "_devserver": attr.label(
             default = Label("//devserver"),
             executable = True,

--- a/internal/karma/ts_web_test.bzl
+++ b/internal/karma/ts_web_test.bzl
@@ -184,13 +184,11 @@ ts_web_test = rule(
             default = Label("//internal/karma:karma_bin"),
             executable = True,
             cfg = "target",
-            single_file = False,
-            allow_files = True,
+            allow_single_file = False,
         ),
         "_conf_tmpl": attr.label(
             default = Label(_CONF_TMPL),
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
     },
 )


### PR DESCRIPTION
This removes the need for --incompatible_disable_deprecated_attr_params