### PR TITLE
Remove dependency on tsickle

### DIFF
--- a/internal/tsc_wrapped/tsc_wrapped.ts
+++ b/internal/tsc_wrapped/tsc_wrapped.ts
@@ -139,34 +139,45 @@ function runOneBuild(
     console.error(diagnostics.format(bazelOpts.target, diags));
     return false;
   }
-
+  const toEmit = program.getSourceFiles().filter(isCompilationTarget);
   const emitResults: ts.EmitResult[] = [];
   const afterTransforms = [fixUmdModuleDeclarations(
       (sf: ts.SourceFile) => compilerHost.amdModuleName(sf))];
-  for (const sf of program.getSourceFiles().filter(isCompilationTarget)) {
-    if (bazelOpts.tsickle) {
-      emitResults.push(tsickle.emitWithTsickle(
+
+  if (bazelOpts.tsickle) {
+    // The 'tsickle' import above is only used in type positions, so it won't
+    // result in a runtime dependency on tsickle.
+    // If the user requests the tsickle emit, then we dynamically require it
+    // here for use at runtime.
+    let optTsickle: typeof tsickle;
+    try {
+      // tslint:disable-next-line:no-require-imports dependency on tsickle only if requested
+      optTsickle = require('tsickle');
+    } catch {
+      throw new Error('When setting bazelOpts { tsickle: true }, ' +
+          'you must also add a devDependency on the tsickle npm package');
+    }
+    for (const sf of toEmit) {
+      emitResults.push(optTsickle.emitWithTsickle(
           program, compilerHost, compilerHost, options, sf,
           /*writeFile*/ undefined,
           /*cancellationToken*/ undefined, /*emitOnlyDtsFiles*/ undefined,
           {afterTs: afterTransforms}));
-    } else {
-      emitResults.push(program.emit(
-          sf, /*writeFile*/ undefined,
-          /*cancellationToken*/ undefined, /*emitOnlyDtsFiles*/ undefined,
-          {after: afterTransforms}));
     }
-  }
-
-  if (bazelOpts.tsickle) {
-    diags.push(...tsickle.mergeEmitResults(emitResults as tsickle.EmitResult[])
-                   .diagnostics);
+    diags.push(...optTsickle.mergeEmitResults(emitResults as tsickle.EmitResult[])
+                     .diagnostics);
   } else {
+    for (const sf of toEmit) {
+        emitResults.push(program.emit(
+            sf, /*writeFile*/ undefined,
+            /*cancellationToken*/ undefined, /*emitOnlyDtsFiles*/ undefined,
+            {after: afterTransforms}));
+    }
+
     for (const d of emitResults) {
       diags.push(...d.diagnostics);
     }
   }
-
   if (diags.length > 0) {
     console.error(diagnostics.format(bazelOpts.target, diags));
     return false;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     },
     "dependencies": {
         "protobufjs": "5.0.0",
-        "tsickle": "0.32.1",
         "tsutils": "2.20.0"
     },
     "devDependencies": {
@@ -28,6 +27,7 @@
         "http-server": "^0.11.1",
         "protractor": "^5.2.0",
         "shelljs": "^0.8.2",
+        "tsickle": "0.32.1",
         "typescript": "2.7.x"
     },
     "scripts": {


### PR DESCRIPTION
There is still a compile-time dependency, so to avoid users having to install tsickle,
this depends on shipping a JS distro of @bazel/typescript on npm