### PR TITLE
Update to rules_nodejs 0.12.4

### DIFF
--- a/examples/app/BUILD.bazel
+++ b/examples/app/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver", "ts_library")
+load("@build_bazel_rules_nodejs//:defs.bzl", "http_server")
 
 ts_library(
     name = "app",
@@ -25,14 +26,12 @@ rollup_bundle(
     deps = [":app"],
 )
 
-nodejs_binary(
+http_server(
     name = "prodserver",
-    args = ["./examples/app"],
     data = [
         "index.html",
         ":bundle",
     ],
-    entry_point = "http-server/bin/http-server",
 )
 
 ts_library(

--- a/examples/googmodule/BUILD.bazel
+++ b/examples/googmodule/BUILD.bazel
@@ -21,4 +21,5 @@ jasmine_node_test(
     data = [
         ":es5_output",
     ],
+    node_modules = "//:node_modules",
 )

--- a/examples/protocol_buffers/BUILD.bazel
+++ b/examples/protocol_buffers/BUILD.bazel
@@ -57,7 +57,7 @@ ts_devserver(
 )
 
 # Test for production mode
-load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:defs.bzl", "http_server", "rollup_bundle", "nodejs_binary")
 
 rollup_bundle(
     name = "bundle",
@@ -86,15 +86,13 @@ genrule(
     cmd = "outs=($(OUTS)); d=$$(dirname $${outs[0]}); for s in $(SRCS); do cp $$s $$d; done",
 )
 
-nodejs_binary(
+http_server(
     name = "prodserver",
-    args = ["./examples/protocol_buffers"],
     data = [
         "index.html",
         ":bundle",
         ":protobufjs",
     ],
-    entry_point = "http-server/bin/http-server",
 )
 
 ts_library(

--- a/examples/some_module/BUILD.bazel
+++ b/examples/some_module/BUILD.bazel
@@ -40,6 +40,7 @@ nodejs_binary(
         ":some_module",
     ],
     entry_point = "build_bazel_rules_typescript/examples/some_module/main.js",
+    node_modules = "//:node_modules",
 )
 
 sh_test(

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -31,6 +31,7 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "jasmine_node_test
 nodejs_binary(
     name = "tsc",
     entry_point = "typescript/lib/tsc.js",
+    node_modules = "@//:node_modules",
     visibility = ["//internal:__subpackages__"],
 )
 
@@ -72,6 +73,7 @@ nodejs_binary(
         ":tsc_wrapped",
     ],
     entry_point = "build_bazel_rules_typescript/internal/tsc_wrapped/tsc_wrapped.js",
+    node_modules = "@//:node_modules",
     templated_args = ["--node_options=--expose-gc"],
     visibility = ["//visibility:public"],
 )
@@ -87,4 +89,5 @@ jasmine_node_test(
     name = "test",
     srcs = [],
     deps = [":test_lib"],
+    node_modules = "//:node_modules",
 )

--- a/internal/e2e/default_tsconfig_test.js
+++ b/internal/e2e/default_tsconfig_test.js
@@ -24,9 +24,9 @@ const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'wksp'));
 const WORKSPACE_BOILERPLATE = `
 http_archive(
     name = "build_bazel_rules_nodejs",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.11.3.zip"],
-    strip_prefix = "rules_nodejs-0.11.3",
-    sha256 = "e8842fa5f5e38f2c826167ff94323d4b5aabd13217cee867d971d6f860cfd730"
+    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.12.4.zip"],
+    strip_prefix = "rules_nodejs-0.12.4",
+    sha256 = "c482700e032b4df60425cb9a6f8f28152fb1c4c947a9d61e6132fc59ce332b16"
 )
 http_archive(
     name = "bazel_skylib",

--- a/internal/e2e/reference_types_directive/BUILD.bazel
+++ b/internal/e2e/reference_types_directive/BUILD.bazel
@@ -22,4 +22,5 @@ ts_library(
 jasmine_node_test(
     name = "test",
     deps = [":test_lib"],
+    node_modules = "//:node_modules",
 )

--- a/package.bzl
+++ b/package.bzl
@@ -38,9 +38,9 @@ def rules_typescript_dependencies():
     _maybe(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.11.5.zip"],
-        strip_prefix = "rules_nodejs-0.11.5",
-        sha256 = "985bf908faa72cc4638c356a99d19ccac223e5dcd8dae695e3157e5c00f53489",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.12.4.zip"],
+        strip_prefix = "rules_nodejs-0.12.4",
+        sha256 = "c482700e032b4df60425cb9a6f8f28152fb1c4c947a9d61e6132fc59ce332b16",
     )
 
     # ts_web_test depends on the web testing rules to provision browsers.


### PR DESCRIPTION
Also make rules forward compatible with npm fine grained deps coming to rules_nodejs in https://github.com/bazelbuild/rules_nodejs/pull/302.

That change requires an explicit node_modules attribute for nodejs_binary and rules that derive from it.