### PR TITLE
Update check_version.js to check correct location of generate_build_file.js

### DIFF
--- a/tools/check_version.js
+++ b/tools/check_version.js
@@ -37,11 +37,11 @@ const npmPackageVersion = process.env.npm_package_version.split('-')[0];
 // If this is a bazel managed deps yarn_install or npm_install then the
 // cwd is $(bazel info
 // output_base)/external/<wksp>/node_modules/@bazel/typescript and there should
-// be $(bazel info output_base)/external/<wksp>/internal/generate_build_file.js
+// be $(bazel info output_base)/external/<wksp>/generate_build_file.js
 // folder
 function isBazelManagedDeps() {
   try {
-    fs.statSync('../../../internal/generate_build_file.js');
+    fs.statSync('../../../generate_build_file.js');
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
npm fine grained deps script `generate_build_file.js` was moved from `<wkps>/internal/generate_build_file.js` to `<wksp>/generate_build_file.js` so that it would not conflict with the `internal` npm package if it is installed (since the script would create an `internal` folder)

This regression was introduced in 0.20.0