### PR TITLE
Move bazelrc to new location

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,7 @@
-import %workspace%/tools/bazel.rc
+build --strategy=TypeScriptCompile=worker
+test --test_output=errors
+
+# Enable debugging tests with --config=debug
+test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
+
+build --workspace_status_command=./tools/bazel_stamp_vars.sh

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -9,7 +9,7 @@ test --test_tag_filters=-manual
 
 # Print all the options that apply to the build.
 # This helps us diagnose which options override others
-# (e.g. /etc/bazel.bazelrc vs. tools/bazel.rc)
+# (e.g. /etc/bazel.bazelrc vs. /.bazelrc)
 build --announce_rc
 
 # Enable experimental CircleCI bazel remote cache proxy

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,7 +1,0 @@
-build --strategy=TypeScriptCompile=worker
-test --test_output=errors
-
-# Enable debugging tests with --config=debug
-test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
-
-build --workspace_status_command=./tools/bazel_stamp_vars.sh


### PR DESCRIPTION
Bazel 0.18 warns about the tools/bazel.rc file