### PR TITLE
Update rules_go to 0.16.0

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -56,9 +56,9 @@ def rules_typescript_dependencies():
     _maybe(
         http_archive,
         name = "io_bazel_rules_go",
-        urls = ["https://github.com/bazelbuild/rules_go/archive/cbc1e32fba771845305f15e341fa26595d4a136d.zip"],
         strip_prefix = "rules_go-cbc1e32fba771845305f15e341fa26595d4a136d",
-        sha256 = "d02b1d8d11fb67fb1e451645256e58a1542170eedd6e2ba160c8540c96f659da",
+        url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.0/rules_go-0.16.0.tar.gz",
+        sha256 = "ee5fe78fe417c685ecb77a0a725dc9f6040ae5beb44a0ba4ddb55453aad23a8a",
     )
 
     # go_repository is defined in bazel_gazelle

--- a/package.bzl
+++ b/package.bzl
@@ -56,7 +56,6 @@ def rules_typescript_dependencies():
     _maybe(
         http_archive,
         name = "io_bazel_rules_go",
-        strip_prefix = "rules_go-cbc1e32fba771845305f15e341fa26595d4a136d",
         url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.0/rules_go-0.16.0.tar.gz",
         sha256 = "ee5fe78fe417c685ecb77a0a725dc9f6040ae5beb44a0ba4ddb55453aad23a8a",
     )


### PR DESCRIPTION
Needed as part of bazelbuild/bazel#6283.