### PR TITLE
fix: do not return empty struct if there is no compile action

### DIFF
--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -94,7 +94,7 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description 
     # A ts_library that has only .d.ts inputs will have no outputs,
     # therefore there are no actions to execute
     if not action_outputs:
-        return struct()
+        return None
 
     action_inputs.extend(_filter_ts_inputs(ctx.files.node_modules))
 


### PR DESCRIPTION
Currently if there is no action for a `ts_library` that just declares `.d.ts` files, the `replay_params` will be set to an empty struct. Design-wise this does not make any sense because there is nothing to be "replayed".

This fixes an issue where the Angular Bazel rules throw an exception if there are "replay_params", but are referring to a struct that does not include the "outputs" property.

```
  target.typescript.replay_params.outputs
struct' object has no attribute 'outputs'
```