### PR TITLE
Update handling of rules_nodejs transitive deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ http_archive(
     strip_prefix = "rules_typescript-0.20.3",
 )
 
-# Fetch our Bazel dependencies that aren't distributed on npm
+# Fetch transitive Bazel dependencies of build_bazel_rules_typescript
 load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
 rules_typescript_dependencies()
+
+# Fetch transitive Bazel dependencies of build_bazel_rules_nodejs
+load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
+rules_nodejs_dependencies()
 
 # Setup TypeScript toolchain
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,6 +23,10 @@ load(
 rules_typescript_dependencies()
 rules_typescript_dev_dependencies()
 
+load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
 
 # Use a bazel-managed npm dependency, allowing us to test resolution to these paths

--- a/package.bzl
+++ b/package.bzl
@@ -78,19 +78,6 @@ def rules_typescript_dependencies():
         sha256 = "ec495cbd19238c9dc488fd65ca1fee56dcb1a8d6d56ee69a49f2ebe69826c261",
     )
 
-    ###############################################
-    # Repeat the dependencies of rules_nodejs here!
-    # We can't load() from rules_nodejs yet, because we've only just fetched it.
-    # But we also don't want to make users load and call the rules_nodejs_dependencies
-    # function because we can do that for them, mostly hiding the transitive dependency.
-    _maybe(
-        http_archive,
-        name = "bazel_skylib",
-        url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.zip",
-        strip_prefix = "bazel-skylib-0.5.0",
-        sha256 = "ca4e3b8e4da9266c3a9101c8f4704fe2e20eb5625b2a6a7d2d7d45e3dd4efffd",
-    )
-
 def rules_typescript_dev_dependencies():
     """
     Fetch dependencies needed for local development, but not needed by users.


### PR DESCRIPTION
BREAKING CHANGES:

rules_typescript_dependencies() will no longer install transitive dependencies of build_bazel_rules_nodejs. User WORKSPACE files will now need to install rules_nodejs transitive deps directly:

```
load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
rules_nodejs_dependencies()
```