### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ filegroup(
     name = "node_modules",
     srcs = glob(
         include = [
+          # Must include .proto files since the tsc_wrapped compiler utilizes them
           "node_modules/**/*.proto",
           "node_modules/**/*.js",
           "node_modules/**/*.d.ts",

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ filegroup(
     name = "node_modules",
     srcs = glob(
         include = [
+          "node_modules/**/*.proto",
           "node_modules/**/*.js",
           "node_modules/**/*.d.ts",
           "node_modules/**/*.json",


### PR DESCRIPTION
I ran into an error using self-managed deps because a `.proto` (I think it was worker_protocol) file was not included in my `@bazel/typescript` node_modules. It turns out that it was not included in the filegroup in my root `BUILD`. Hopefully this makes the getting started process a lot smoother for folks that need self-managed deps for some reason still.