### PR TITLE
tsc_wrapped: report syntax and semantic errors

### DIFF
--- a/internal/tsc_wrapped/tsc_wrapped.ts
+++ b/internal/tsc_wrapped/tsc_wrapped.ts
@@ -231,10 +231,14 @@ function runFromOptions(
 function emitWithTypescript(
     program: ts.Program, compilationTargets: ts.SourceFile[]): ts.Diagnostic[] {
   const diagnostics: ts.Diagnostic[] = [];
+  diagnostics.push(...program.getSyntacticDiagnostics())
+  diagnostics.push(...program.getOptionsDiagnostics())
+  diagnostics.push(...program.getGlobalDiagnostics())
   for (const sf of compilationTargets) {
     const result = program.emit(sf);
     diagnostics.push(...result.diagnostics);
   }
+  diagnostics.push(...program.getSemanticDiagnostics())
   return diagnostics;
 }
 


### PR DESCRIPTION
Instead of reporting compilation errors only, tsc_wrapped should report other kinds of errors. 

This CL mirrors the behavior in the original tsc. 

Fixes #335 