### PR TITLE
fix: use Buffer.from instead of the deprecated Buffer constructor

### DIFF
--- a/internal/karma/index.ts
+++ b/internal/karma/index.ts
@@ -55,7 +55,7 @@ function initConcatJs(logger, emitter, basePath) {
       }
     });
 
-    bundleFile.sha = sha1(new Buffer(bundleFile.content));
+    bundleFile.sha = sha1(Buffer.from(bundleFile.content));
     bundleFile.mtime = new Date();
     included.unshift(bundleFile);
 


### PR DESCRIPTION
Fixes #313