### PR TITLE
initial tsetse rule refactoring

### DIFF
--- a/internal/tsetse/checker.ts
+++ b/internal/tsetse/checker.ts
@@ -47,36 +47,8 @@ export class Checker {
    * `nodeKind` node in `nodeHandlersMap` map. After all rules register their
    * handlers, the source file AST will be traversed.
    */
-  on(nodeKind: ts.SyntaxKind.BinaryExpression,
-     handlerFunction: (checker: Checker, node: ts.BinaryExpression) => void,
-     code: number): void;
-  on(nodeKind: ts.SyntaxKind.ConditionalExpression,
-     handlerFunction:
-         (checker: Checker, node: ts.ConditionalExpression) => void,
-     code: number): void;
-  on(nodeKind: ts.SyntaxKind.WhileStatement,
-     handlerFunction: (checker: Checker, node: ts.WhileStatement) => void,
-     code: number): void;
-  on(nodeKind: ts.SyntaxKind.IfStatement,
-     handlerFunction: (checker: Checker, node: ts.IfStatement) => void,
-     code: number): void;
-  on(nodeKind: ts.SyntaxKind.CallExpression,
-     handlerFunction: (checker: Checker, node: ts.CallExpression) => void,
-     code: number): void;
-  on(nodeKind: ts.SyntaxKind.PropertyDeclaration,
-     handlerFunction: (checker: Checker, node: ts.PropertyDeclaration) => void,
-     code: number): void;
-  on(nodeKind: ts.SyntaxKind.ElementAccessExpression,
-     handlerFunction: (checker: Checker, node: ts.ElementAccessExpression) => void,
-     code: number): void;
-  on(nodeKind: ts.SyntaxKind.ImportDeclaration,
-     handlerFunction: (checker: Checker, node: ts.ImportDeclaration) => void,
-     code: number): void;
-  on(nodeKind: ts.SyntaxKind,
-     handlerFunction: (checker: Checker, node: ts.Node) => void,
-     code: number): void;
   on<T extends ts.Node>(
-      nodeKind: ts.SyntaxKind,
+      nodeKind: T['kind'],
       handlerFunction: (checker: Checker, node: T) => void, code: number) {
     const newHandler: Handler = {handlerFunction, code};
     const registeredHandlers: Handler[]|undefined =

--- a/internal/tsetse/rules/ban_expect_truthy_promise_rule.ts
+++ b/internal/tsetse/rules/ban_expect_truthy_promise_rule.ts
@@ -21,12 +21,8 @@ export class Rule extends AbstractRule {
   }
 }
 
-function checkForTruthy(checker: Checker, node: ts.Node) {
+function checkForTruthy(checker: Checker, node: ts.PropertyAccessExpression) {
   const tc = checker.typeChecker;
-
-  if (!tsutils.isPropertyAccessExpression(node)) {
-    return;
-  }
 
   if (node.name.getText() !== 'toBeTruthy') {
     return;

--- a/internal/tsetse/rules/equals_nan_rule.ts
+++ b/internal/tsetse/rules/equals_nan_rule.ts
@@ -20,19 +20,26 @@ export class Rule extends AbstractRule {
 }
 
 function checkBinaryExpression(checker: Checker, node: ts.BinaryExpression) {
-  if (node.left.getText() === 'NaN' || node.right.getText() === 'NaN') {
-    const operator = node.operatorToken;
-    if (operator.kind == ts.SyntaxKind.EqualsEqualsToken ||
-        operator.kind === ts.SyntaxKind.EqualsEqualsEqualsToken) {
+  const isLeftNaN = ts.isIdentifier(node.left) && node.left.text === 'NaN';
+  const isRightNaN = ts.isIdentifier(node.right) && node.right.text === 'NaN';
+  if (!isLeftNaN && !isRightNaN) {
+    return;
+  }
+
+  switch (node.operatorToken.kind) {
+    case ts.SyntaxKind.EqualsEqualsToken:
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
       checker.addFailureAtNode(
-          node,
-          `x ${operator.getText()} NaN is always false; use isNaN(x) instead`);
-    }
-    if (operator.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken ||
-        operator.kind === ts.SyntaxKind.ExclamationEqualsToken) {
+        node,
+        `x ==/=== NaN is always false; use isNaN(x) instead`,
+      );
+      break;
+    case ts.SyntaxKind.ExclamationEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
       checker.addFailureAtNode(
-          node,
-          `x ${operator.getText()} NaN is always true; use !isNaN(x) instead`);
-    }
+        node,
+        `x !=/!== NaN is always true; use !isNaN(x) instead`,
+      );
+      break;
   }
 }


### PR DESCRIPTION
`getText()` usage should be avoided as it is an expensive call.
minor operation re-ordering to favor AST node checks over type analysis.
favor TS native methods over `tsutils`, when available.

`check-return-value` and `ban-promise-as-condition` will be addressed in a forthcoming PR.