### PR TITLE
Make powershell.exe available at build time

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,8 +40,12 @@ platforms:
     run_targets:
     - "//:gazelle"
     - "@nodejs//:yarn"
+    build_flags:
+    - "--action_env=PATH"
     build_targets:
     - "..."
     - "@disable_tsetse_for_external_test//..."
+    test_flags:
+    - "--test_env=PATH"
     test_targets:
     - "..."


### PR DESCRIPTION
After flipping `--experimental_strict_action_env`, we need to pass `--action_env=PATH` to make sure some specific tools are available on Windows.
Fixing https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/4#a868eb9b-dc52-4ce1-8adb-0da82e8a407b


