### PR TITLE
Do TseTse checks with typechecker later

### DIFF
--- a/internal/tsetse/rules/check_return_value_rule.ts
+++ b/internal/tsetse/rules/check_return_value_rule.ts
@@ -55,6 +55,9 @@ export class Rule extends AbstractRule {
 }
 
 function checkCallExpression(checker: Checker, node: ts.CallExpression) {
+  if (tsutils.isExpressionValueUsed(node)) {
+    return;
+  }  
   // Check if this CallExpression is one of the well-known functions and returns
   // a non-void value that is unused.
   const signature = checker.typeChecker.getResolvedSignature(node);
@@ -68,9 +71,6 @@ function checkCallExpression(checker: Checker, node: ts.CallExpression) {
     // anyway. Therefore we short-circuit hasCheckReturnValueJsDoc().
     if (!isBlackListed(node, checker.typeChecker) &&
         !hasCheckReturnValueJsDoc(node, checker.typeChecker)) {
-      return;
-    }
-    if (tsutils.isExpressionValueUsed(node)) {
       return;
     }
 

--- a/internal/tsetse/rules/must_use_promises_rule.ts
+++ b/internal/tsetse/rules/must_use_promises_rule.ts
@@ -24,6 +24,10 @@ export class Rule extends AbstractRule {
 }
 
 function checkCallExpression(checker: Checker, node: ts.CallExpression) {
+  if (tsutils.isExpressionValueUsed(node) || !inAsyncFunction(node)) {
+    return;
+  }
+  
   const signature = checker.typeChecker.getResolvedSignature(node);
   if (signature === undefined) {
     return;
@@ -34,12 +38,7 @@ function checkCallExpression(checker: Checker, node: ts.CallExpression) {
     return;
   }
 
-  if (tsutils.isExpressionValueUsed(node)) {
-    return;
-  }
-
-  if (inAsyncFunction(node) &&
-      tsutils.isThenableType(checker.typeChecker, node)) {
+  if (tsutils.isThenableType(checker.typeChecker, node)) {
     checker.addFailureAtNode(node, FAILURE_STRING);
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
The typechecker is known to be slow.

By moving the non-typechecker checks earlier in the process, I was able to observe significant savings in the `perfTrace.wrap` total times:
- `CheckReturnValueRule`: 1,036ms, down from 2,102ms
- `MustUsePromisesRule`: 119ms, down from 1,174ms

Issue Number: https://github.com/angular/angular/issues/27426

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information



