### PR TITLE
fix(karma): do not show error message if unnamed amd module is loaded

### DIFF
--- a/internal/e2e/npm_packages/karma/BUILD.bazel
+++ b/internal/e2e/npm_packages/karma/BUILD.bazel
@@ -21,4 +21,10 @@ ts_web_test_suite(
         "@io_bazel_rules_webtesting//browsers:chromium-local",
         "@io_bazel_rules_webtesting//browsers:firefox-local",
     ],
+    static_files = [
+        ":unnamed-amd-module.js",
+    ],
+    deps = [
+        ":requirejs-config.js",
+    ],
 )

--- a/internal/e2e/npm_packages/karma/amd-modules.spec.js
+++ b/internal/e2e/npm_packages/karma/amd-modules.spec.js
@@ -1,0 +1,32 @@
+define('npm_packages_karma_e2e/amd-modules.spec', ['require'], (require) => {
+
+  describe('AMD module loading', () => {
+
+    describe('unnamed amd modules', () => {
+
+      it('should not warn if module is configured as static file', doneFn => {
+        spyOn(console, 'error');
+
+        require(['unnamed-module'], () => {
+          // Loading such an anonymous AMD module should not cause any error messages about
+          // a missing timestamp. This is a limitation of the "karma-requirejs" plugin which
+          // by default always prints an error for requests through Karma's proxy.
+          // See: https://github.com/karma-runner/karma-requirejs/issues/6
+          expect(console.error).toHaveBeenCalledTimes(0);
+          doneFn();
+        });
+      });
+
+      it('should warn if module is not specified as static file', doneFn => {
+        spyOn(console, 'error').and.callThrough();
+
+        require(['unnamed-module-invalid-file'],
+            /* loaded callback */ () => {},
+            /* error callback */ () => {
+          expect(console.error).toHaveBeenCalledWith(jasmine.stringMatching(/no timestamp/));
+          doneFn();
+        });
+      });
+    });
+  })
+});

--- a/internal/e2e/npm_packages/karma/requirejs-config.js
+++ b/internal/e2e/npm_packages/karma/requirejs-config.js
@@ -1,0 +1,8 @@
+require.config({
+  paths: {
+    // Configure some fake AMD module that exists and should not cause a loading
+    // error message from the "karma-requirejs" plugin which is enabled by default.
+    'unnamed-module': '/base/npm_packages_karma_e2e/unnamed-amd-module',
+    'unnamed-module-invalid-file': '/some-invalid-file-path',
+  }
+});

--- a/internal/e2e/npm_packages/karma/unnamed-amd-module.js
+++ b/internal/e2e/npm_packages/karma/unnamed-amd-module.js
@@ -1,0 +1,5 @@
+// Unnamed AMD module definition which needs to be manually configured through
+// a "requirejs" configuration whenever this module should be loaded.
+define(function() {
+  // Just an empty definition. Nothing to assert here.
+});

--- a/internal/karma/karma.conf.js
+++ b/internal/karma/karma.conf.js
@@ -165,6 +165,19 @@ try
     // base path that will be used to resolve all patterns
     // (eg. files, exclude)
     overrideConfigValue(conf, 'basePath', 'TMPL_runfiles_path');
+
+    // Do not show "no timestamp" errors from "karma-requirejs" for proxied file
+    // requests. Files which are passed as "static_files" are proxied by default and
+    // therefore should not cause such an exception when loaded as expected.
+    // See: https://github.com/karma-runner/karma-requirejs/issues/6
+    const requireJsShowNoTimestampsError = '^(?!/base/).*$';
+
+    if (conf.client) {
+      overrideConfigValue(conf.client, 'requireJsShowNoTimestampsError',
+          requireJsShowNoTimestampsError);
+    } else {
+      conf.client = {requireJsShowNoTimestampsError};
+    }
   }
 
   /**
@@ -388,7 +401,7 @@ try
         throw new Error('Invalid base karma configuration. Expected config function to be exported.');
       }
       const originalSetConfig = config.set;
-      config.set = function(c) { conf = c; }
+      config.set = function(c) { conf = c; };
       baseConf(config);
       config.set = originalSetConfig;
       if (DEBUG) console.info(`Base karma configuration: ${JSON.stringify(conf, null, 2)}`);


### PR DESCRIPTION
Currently unnamed AMD modules need to be manually configured through a `require.config` call. This then configures Require.JS to load the unnamed AMD module dynamically as a "static file". Meaning that the unnamed AMD module needs to be specified within the `ts_web_test_suite` `static_files` attribute.

All static files will be proxied by default and can be loaded through `${location}/base/{workspace}/{path}` and therefore it's common to load static files that way.

**The problem** here is that the "karma-requirejs" plugin by default shows an error message if something is loaded through a karma proxy. We need to disable this warning for such known & proxied requests so that the error output is clean and does not cause confusion what "no timestamp for XXX" means.