### PR TITLE
Use xlarge resource_class for CircleCI test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
   # Runs end-to-end browser tests.
   test:
     <<: *job_defaults
+    resource_class: xlarge
     steps:
       - checkout:
           <<: *post_checkout


### PR DESCRIPTION
This will make landing PRs easier since the test job is flakey on the default resource_class: https://github.com/bazelbuild/rules_typescript/pull/376