### PR TITLE
ci: lower memory ceiling

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -25,8 +25,8 @@ build --experimental_repository_cache=/home/circleci/bazel_repository_cache
 
 # Workaround https://github.com/bazelbuild/bazel/issues/3645
 # Bazel doesn't calculate the memory ceiling correctly when running under Docker.
-# Limit Bazel to consuming 2560K of RAM
-build --local_resources=2560,1.0,1.0
+# Limit Bazel to consuming 2360K of RAM
+build --local_resources=2360,1.0,1.0
 # Also limit Bazel's own JVM heap to stay within our 4G container limit
 startup --host_jvm_args=-Xmx3g
 # Since the default CircleCI container has only 4G, limiting the memory


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Both https://github.com/bazelbuild/rules_typescript/pull/327 and https://github.com/bazelbuild/rules_typescript/pull/378 have circleci `test` jobs being killed:
```
Server terminated abruptly (error code: 14, error message: '', log file: '/home/circleci/.cache/bazel/_bazel_circleci/cced162ff126e466524550c57f0d7df5/server/jvm.out')
```

According to the note in https://github.com/bazelbuild/rules_typescript/blob/4a087c084cab78e610f91764db52e705aefa1814/.circleci/bazel.rc#L32-L38 this means the memory limit should be reduced.


## What is the new behavior?
Lower memory limit.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
