### PR TITLE
fix: tsc_wrapped depends on @npm//tsickle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -64,7 +64,10 @@ js_library(
 # set which is required to support the call to `global.gc()`.
 nodejs_binary(
     name = "@bazel/typescript/tsc_wrapped",
-    data = ["@npm//@bazel/typescript"],
+    data = [
+        "@npm//@bazel/typescript",
+        "@npm//tsickle",
+    ],
     entry_point = "@bazel/typescript/tsc_wrapped/tsc_wrapped.js",
     install_source_map_support = False,
     templated_args = ["--node_options=--expose-gc"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
With Bazel 0.22, the current `tsc_wrapped` target, when used to compile `ts_library` targets that need to yield es5/es6 files, causes runtime errors such as
```text
ERROR: /home/zhongming/git/LogiOcean/examples/ts/googmodule/BUILD:5:1: Compiling TypeScript (devmode) //examples/ts/googmodule:googmodule failed (Exit 1): tsc_wrapped failed: error executing command
  (cd /home/zhongming/.cache/bazel/_bazel_zhongming/2aea414f4d422ad78870bb37da8563ec/execroot/logi && \
  exec env - \
    PATH=/bin:/usr/bin \
  bazel-out/host/bin/external/build_bazel_rules_typescript/@bazel/typescript/tsc_wrapped @@bazel-out/k8-fastbuild/bin/examples/ts/googmodule/googmodule_es5_tsconfig.json)
Execution platform: @bazel_tools//platforms:host_platform
Compilation failed Error: When setting bazelOpts { tsickle: true }, you must also add a devDependency on the tsickle npm package
    at emitWithTsickle (/home/zhongming/.cache/bazel/_bazel_zhongming/2aea414f4d422ad78870bb37da8563ec/execroot/logi/bazel-out/host/bin/external/build_bazel_rules_typescript/@bazel/typescript/tsc_wrapped.runfiles/npm/node_modules/@bazel/typescript/tsc_wrapped/tsc_wrapped.js:315:19)
    at runFromOptions (/home/zhongming/.cache/bazel/_bazel_zhongming/2aea414f4d422ad78870bb37da8563ec/execroot/logi/bazel-out/host/bin/external/build_bazel_rules_typescript/@bazel/typescript/tsc_wrapped.runfiles/npm/node_modules/@bazel/typescript/tsc_wrapped/tsc_wrapped.js:266:27)
    at runOneBuild (/home/zhongming/.cache/bazel/_bazel_zhongming/2aea414f4d422ad78870bb37da8563ec/execroot/logi/bazel-out/host/bin/external/build_bazel_rules_typescript/@bazel/typescript/tsc_wrapped.runfiles/npm/node_modules/@bazel/typescript/tsc_wrapped/tsc_wrapped.js:213:20)
    at Socket.<anonymous> (/home/zhongming/.cache/bazel/_bazel_zhongming/2aea414f4d422ad78870bb37da8563ec/execroot/logi/bazel-out/host/bin/external/build_bazel_rules_typescript/@bazel/typescript/tsc_wrapped.runfiles/npm/node_modules/@bazel/typescript/tsc_wrapped/worker.js:140:36)
    at Socket.emit (events.js:182:13)
    at emitReadable_ (_stream_readable.js:534:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The `ts_library()` rule works fine for all of its outputs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
