### PR TITLE
Add missing file for devserver to npm package

### DIFF
--- a/internal/devserver/BUILD
+++ b/internal/devserver/BUILD
@@ -33,6 +33,7 @@ filegroup(
     name = "npm_package_assets",
     srcs = [
         "BUILD",
+        "launcher_template.sh",
         "package.json",
         "ts_devserver.bzl",
         "yarn.lock",


### PR DESCRIPTION
Fixes break caused by g3 sync not running CI

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.
