### PR TITLE
Generate npm_packages in internal/e2e/npm_packages/test.sh for smoother local testing

### DIFF
--- a/internal/e2e/npm_packages/test.sh
+++ b/internal/e2e/npm_packages/test.sh
@@ -2,8 +2,9 @@
 
 set -u -e -o pipefail
 
-cd $(dirname "$0")
-TESTS_ROOT_DIR=$(pwd)
+TESTS_ROOT_DIR=$(cd $(dirname "$0"); pwd)
+TYPESCRIPT_ROOT_DIR=$(cd $TESTS_ROOT_DIR/../../..; pwd)
+KARMA_ROOT_DIR=$(cd $TESTS_ROOT_DIR/../../../internal/karma; pwd)
 
 echo ""
 echo "#################################################################################"
@@ -15,16 +16,19 @@ echo ""
 echo "Run this script with '--update-lock-files' to update yarn.lock files instead of running tests"
 echo ""
 
-# Determine the absolute paths to the generated @bazel/typescript and @bazel/karma npm packages
-cd $TESTS_ROOT_DIR/../../..
+# Generate the npm packages @bazel/typescript and @bazel/karma npm packages and
+# determine their absolute paths in bazel-bin
+cd $TYPESCRIPT_ROOT_DIR
 BAZEL=$(pwd)/node_modules/.bin/bazel
 if [[ ! -f $BAZEL ]] ; then
   echo "Bazel not found under $BAZEL"
   exit 1
 fi
+$BAZEL build //:npm_package
 BAZEL_BIN_TYPESCRIPT=$($BAZEL info bazel-bin)
 BAZEL_TYPESCRIPT_NPM_PACKAGE=$BAZEL_BIN_TYPESCRIPT/npm_package
-cd $TESTS_ROOT_DIR/../../../internal/karma
+cd $KARMA_ROOT_DIR
+$BAZEL build //:npm_package
 BAZEL_BIN_KARMA=$($BAZEL info bazel-bin)
 BAZEL_KARMA_NPM_PACKAGE=$BAZEL_BIN_KARMA/npm_package
 echo "@bazel/typescript: $BAZEL_TYPESCRIPT_NPM_PACKAGE"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         }
     },
     "scripts": {
-        "pree2e": "webdriver-manager update $CHROMEDRIVER_VERSION_ARG && bazel build //examples/app:e2e //examples/protocol_buffers:e2e //:npm_package && cd internal/karma; bazel build //:npm_package",
+        "pree2e": "webdriver-manager update $CHROMEDRIVER_VERSION_ARG && bazel build //examples/app:e2e //examples/protocol_buffers:e2e",
         "e2e": "yarn e2e-bazel-external && yarn e2e-examples-app-devserver && yarn e2e-examples-app-prodserver && yarn e2e-examples-protobuf-devserver && yarn e2e-examples-protobuf-prodserver && yarn e2e-npm_packages && yarn e2e-typescript_3.1",
         "e2e-bazel-external": "jasmine internal/e2e/default_tsconfig_test.js",
         "e2e-examples-app-devserver": "concurrently \"bazel run //examples/app:devserver\" \"while ! nc -z 127.0.0.1 8080; do sleep 1; done && protractor --suite app\" --kill-others --success first",


### PR DESCRIPTION
This is so you don't have to call `yarn pree2e` before calling `yarn e2e-npm_packages` when running e2e tests locally