### PR TITLE
Don't treat tsickle warnings as errors

### DIFF
--- a/internal/tsc_wrapped/tsc_wrapped.ts
+++ b/internal/tsc_wrapped/tsc_wrapped.ts
@@ -241,9 +241,13 @@ function runFromOptions(
   } else {
     diagnostics = emitWithTypescript(program, compilationTargets);
   }
-
-  if (diagnostics.length > 0) {
-    console.error(bazelDiagnostics.format(bazelOpts.target, diagnostics));
+  const warnings = diagnostics.filter(d => d.category == ts.DiagnosticCategory.Warning);
+  if (warnings.length > 0) {
+    console.warn(bazelDiagnostics.format(bazelOpts.target, warnings));
+  }
+  const errors = diagnostics.filter(d => d.category == ts.DiagnosticCategory.Error);
+  if (errors.length > 0) {
+    console.error(bazelDiagnostics.format(bazelOpts.target, errors));
     debug('compilation failed at', new Error().stack!);
     return false;
   }


### PR DESCRIPTION
Not sure if you want to merge this or not, but figured I'd put it here anyway.
Happy to add a new test if you want me to before merging.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/bazelbuild/rules_typescript/issues/377


## What is the new behavior?

```
$ bazel build //src/reducers:reducers
INFO: From Compiling TypeScript (devmode) //src/reducers:reducers:
src/reducers/reducers.ts:38:1 - warning TS0: @namespace annotations are redundant with TypeScript equivalents

38 /** @namespace */
   ~~~~~~~~~~~~~~~~~

Target //src/reducers:reducers up-to-date:
  dist/bin/src/reducers/reducers.d.ts
INFO: Build completed successfully, 3 total actions
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
