### PR TITLE
Closure Compiler Proof of Concept

### DIFF
--- a/examples/closure/BUILD.bazel
+++ b/examples/closure/BUILD.bazel
@@ -1,0 +1,26 @@
+load(":closure.bzl", "closure_ts_import")
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_binary", "closure_js_library")
+load("//internal:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "foo_ts_library",
+    srcs = ["foo.ts"],
+    #tsickle=True,
+)
+
+closure_ts_import(
+    name = "foo_closure_js_library",
+    deps = [":foo_ts_library"],
+)
+
+closure_js_library(
+    name = "closure_lib",
+    srcs = ["main.js"],
+    deps = [":foo_closure_js_library"],
+)
+
+closure_js_binary(
+    name = "closure",
+    entry_points = ["npm_bazel_typescript.examples.closure.main"],
+    deps = ["closure_lib"],
+)

--- a/examples/closure/closure.bzl
+++ b/examples/closure/closure.bzl
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_closure//closure:defs.bzl", "CLOSURE_JS_TOOLCHAIN_ATTRS", "create_closure_js_library")
+
+default_ts_suppress = [
+    "checkTypes",
+    "strictCheckTypes",
+    "reportUnknownTypes",
+    "analyzerChecks",
+    "JSC_EXTRA_REQUIRE_WARNING",
+    "unusedLocalVariables",
+]
+
+def _closure_ts_import(ctx):
+    js_deps = []
+    # TODO: get runtime_deps from ts_library
+    js_sources = depset(transitive = [dep.typescript.transitive_es6_sources for dep in ctx.attr.deps]).to_list()
+    suppress = ctx.attr.suppress + default_ts_suppress
+    js_library = create_closure_js_library(ctx, js_sources, js_deps, [], suppress)
+    return struct(
+        files=depset([]),
+        runfiles=ctx.runfiles(files=js_sources, collect_default=True, collect_data=True),
+        exports=js_library.exports,
+        closure_js_library=js_library.closure_js_library,
+    )
+
+closure_ts_import = rule(
+    implementation = _closure_ts_import,
+    attrs = dict({
+        "deps": attr.label_list(providers = ["typescript"]),
+        "suppress": attr.string_list(),
+    }, **CLOSURE_JS_TOOLCHAIN_ATTRS),
+)

--- a/examples/closure/foo.ts
+++ b/examples/closure/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+    console.log('foo');
+}

--- a/examples/closure/main.js
+++ b/examples/closure/main.js
@@ -1,0 +1,3 @@
+goog.module('npm_bazel_typescript.examples.closure.main');
+const foo = goog.require('npm_bazel_typescript.examples.closure.foo');
+foo.foo();

--- a/internal/build_defs.bzl
+++ b/internal/build_defs.bzl
@@ -76,7 +76,7 @@ def _filter_ts_inputs(all_inputs):
         if f.path.endswith(".js") or f.path.endswith(".ts") or f.path.endswith(".json")
     ]
 
-def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description = "prodmode"):
+def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description = "prodmode", using_tsickle=False):
     externs_files = []
     action_inputs = []
     action_outputs = []
@@ -88,9 +88,12 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description 
         else:
             action_outputs.append(output)
 
-    # TODO(plf): For now we mock creation of files other than {name}.js.
-    for externs_file in externs_files:
-        ctx.actions.write(output = externs_file, content = "")
+    if using_tsickle:
+        action_outputs.extend(externs_files)
+    else:
+        # TODO(plf): For now we mock creation of files other than {name}.js.
+        for externs_file in externs_files:
+            ctx.actions.write(output = externs_file, content = "")
 
     # A ts_library that has only .d.ts inputs will have no outputs,
     # therefore there are no actions to execute

--- a/internal/common/compilation.bzl
+++ b/internal/common/compilation.bzl
@@ -313,6 +313,20 @@ def compile_ts(
     # .d.ts (or even errors) from the altered Closure-style JS emit.
     tsconfig_es6["compilerOptions"]["declaration"] = False
     tsconfig_es6["compilerOptions"].pop("declarationDir")
+
+    # TODO: I'm not sure how we should control this.
+    # Should this be an attribute you can set on a library?
+    # Or should we have separate .es6.js and .closure.js outputs
+    # so downstream consumers can choose which to use?
+    tsconfig_es6["bazelOptions"]["tsickle"] = True
+
+    # TODO: Again I'm not sure how this should be configured.
+    # I switched to using goog.modules after experiencing
+    # major bugs in Closure Compiler's handling of es6 imports.
+    # But that may be fixed now. Would es6 imports be easier than
+    # explaining module names and entry_points to people?
+    tsconfig_es6["bazelOptions"]["googmodule"] = True
+
     outputs = transpiled_closure_js + tsickle_externs
 
     node_profile_args = []
@@ -351,6 +365,7 @@ def compile_ts(
             outputs,
             ctx.outputs.tsconfig,
             node_profile_args,
+            using_tsickle=True,
         )
 
         devmode_manifest = ctx.actions.declare_file(ctx.label.name + ".es5.MF")

--- a/internal/ts_repositories.bzl
+++ b/internal/ts_repositories.bzl
@@ -18,6 +18,7 @@
 # Parts of this BUILD file only necessary when building within the bazelbuild/rules_typescript repo.
 # The generated `@bazel/typescript` npm package contains a trimmed BUILD file using # DEV-ONLY fences.
 load("@bazel_gazelle//:deps.bzl", "go_repository")
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
 
 # END-DEV-ONLY
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "check_rules_nodejs_version", "yarn_install")
@@ -78,5 +79,7 @@ def ts_setup_dev_workspace():
         commit = "3fb116b820352b7f0c281308a4d6250c22d94e27",
         importpath = "github.com/mattn/go-isatty",
     )
+
+    closure_repositories()
 
 # END-DEV-ONLY

--- a/package.bzl
+++ b/package.bzl
@@ -92,6 +92,17 @@ def rules_typescript_dev_dependencies():
         strip_prefix = "bazel-skylib-d7c5518fa061ae18a20d00b14082705d3d2d885d",
     )
 
+    # rules_closure for closure example
+    _maybe(
+        http_archive,
+        name = "io_bazel_rules_closure",
+        sha256 = "637534d535c5b2b56dd9753e2f6a7abae3b53afcade15ad4da6314d290b1d328",
+        strip_prefix = "rules_closure-1e531288a47623c6631cadfc4c18aa08edc30895",
+        urls = [
+            "https://github.com/bazelbuild/rules_closure/archive/1e531288a47623c6631cadfc4c18aa08edc30895.tar.gz",
+        ],
+    )
+
     #############################################
     # Dependencies for generating documentation #
     #############################################


### PR DESCRIPTION

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
You can't compile a ts_library with closure_js_binary.
Issue Number: #344


## What is the new behavior?
This is a minimal proof of concept for compiling a ts_library with the closure compiler.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Open Questions:
1. Should ts_library automatically get the closure_js_library provider, or should there be a separate wrapper like this?
2. How do we control whether tsickle runs and whether to use goog.module style output?

Also this doesn't let a ts_library depend on closure typed javascript. For that we at a minimum need the ts_declaration rule so you can wrap a closure_js_library in a .d.ts.