### PR TITLE
Fix downstream @bazel/typescript package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -59,7 +59,6 @@ js_library(
 npm_package(
     name = "npm_bazel_typescript_package",
     srcs = [
-        "//devserver:npm_package_assets",
         "//third_party/github.com/bazelbuild/bazel/src/main/protobuf:npm_package_assets",
         "//internal:common/compilation.bzl",
         "//internal:common/json_marshal.bzl",

--- a/devserver/BUILD.bazel
+++ b/devserver/BUILD.bazel
@@ -64,11 +64,3 @@ go_binary(
     pure = "on",
     visibility = ["//visibility:public"],
 )
-
-filegroup(	
-    name = "npm_package_assets",	
-    srcs = [	
-        "BUILD.bazel",	
-    ],	
-    visibility = ["//visibility:public"],	
-)


### PR DESCRIPTION
It was picking up a build file containing a rules_go dependency.
This was caught by our new Renovate setup which sent a red PR:
https://circleci.com/gh/bazelbuild/rules_nodejs/5625#tests/containers/3
