### PR TITLE
Use the canonical name for JS modules in node_modules

### DIFF
--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -340,6 +340,10 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
       }
     }
 
+    if (fileName.startsWith('node_modules/')) {
+      return fileName.substring('node_modules/'.length);
+    }
+
     // path/to/file ->
     // myWorkspace/path/to/file
     return path.posix.join(workspace, fileName);


### PR DESCRIPTION
*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.
