### PR TITLE
Don't test on Ubuntu 14.04

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,16 +1,5 @@
 ---
 platforms:
-  ubuntu1404:
-    run_targets:
-    - "//:gazelle"
-    - "@nodejs//:yarn"
-    build_targets:
-    - "..."
-    test_flags:
-    # TODO(gregmagolan): shared libs needed by chrome & firefox not available on ubuntu1404
-    - "--test_tag_filters=-browser:chromium-local,-browser:firefox-local"
-    test_targets:
-    - "..."
   ubuntu1604:
     run_targets:
     - "//:gazelle"
@@ -19,6 +8,17 @@ platforms:
     - "..."
     test_flags:
     # TODO(gregmagolan): shared libs needed by chrome & firefox not available on ubuntu1604
+    - "--test_tag_filters=-browser:chromium-local,-browser:firefox-local"
+    test_targets:
+    - "..."
+  ubuntu1804:
+    run_targets:
+    - "//:gazelle"
+    - "@nodejs//:yarn"
+    build_targets:
+    - "..."
+    test_flags:
+    # TODO(gregmagolan): shared libs needed by chrome & firefox not available on ubuntu1404
     - "--test_tag_filters=-browser:chromium-local,-browser:firefox-local"
     test_targets:
     - "..."


### PR DESCRIPTION
Ubuntu 14.04 is about to be end-of-life and Bazel CI will stop supporting it shortly afterwards.

Context: https://groups.google.com/d/msg/bazel-dev/_D6XzfNkQQE/8TNKiNmsCAAJ
