### PR TITLE
Update rules_nodejs to 0.28.0

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -30,8 +30,8 @@ def rules_typescript_dev_dependencies():
     _maybe(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        sha256 = "213dcf7e72f3acd4d1e369b7a356f3e5d9560f380bd655b13b7c0ea425d7c419",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.27.9/rules_nodejs-0.27.9.tar.gz"],
+        sha256 = "4c702ffeeab2d24dd4101601b6d27cf582d2e0d4cdc3abefddd4834664669b6b",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.28.0/rules_nodejs-0.28.0.tar.gz"],
     )
 
     # For protocol buffers


### PR DESCRIPTION
This allows testing //internal:tests on Windows
with Bazel 0.25.0 rc8 and
--incompatible_windows_native_test_wrapper (see
https://github.com/bazelbuild/bazel/issues/6622).

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `@build_bazel_rules_nodejs` external repository is rules_nodes 0.27.9, and `//internal:test` fails on Windows with Bazel 0.25.0 rc8 and `--incompatible_windows_native_test_wrapper`.

## What is the new behavior?

The `@build_bazel_rules_nodejs` external repository is rules_nodes 0.28.0, and said test passes with 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Maybe, I don't know.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
