### PR TITLE
Fix path to worker_protocol.proto in ts_library for @npm/typescript package...

### DIFF
--- a/internal/tsc_wrapped/worker.ts
+++ b/internal/tsc_wrapped/worker.ts
@@ -72,7 +72,7 @@ declare namespace workerProto {
  */
 function loadWorkerPb() {
   const protoPath =
-      '../worker_protocol.proto';
+      '../../third_party/github.com/bazelbuild/bazel/src/main/protobuf/worker_protocol.proto';
 
   // Use node module resolution so we can find the .proto file in any of the
   // root dirs


### PR DESCRIPTION
…downstream in rules_nodejs

This was broken after rules_nodejs was updated set `--preserve-symlinks-main` for 0.30.2 and rules_typescript was updated to rules_nodejs 0.30.2 here https://github.com/bazelbuild/rules_typescript/commit/c6fdfefe4b245683de4836a38bbc0ca4bc4ae8eb which made the following change necessary to fix the local build https://github.com/bazelbuild/rules_typescript/commit/c6fdfefe4b245683de4836a38bbc0ca4bc4ae8eb#diff-118aceecde6f4c3cc18c0811d4bb3f48.

That change fixed the local build but broke the downstream usage of ts_library since the path to the proto file in the `@bazel/typescript` npm package needs to be relative.