### PR TITLE
Fix wrong format in patch file

### DIFF
--- a/revert_rules_go_commit_4442d82a001f378d0605cbbca3fb529979a1c3a6.patch
+++ b/revert_rules_go_commit_4442d82a001f378d0605cbbca3fb529979a1c3a6.patch
@@ -1322,7 +1322,7 @@ deleted file mode 100644
 index c9af3f85..00000000
 --- a/tests/core/runfiles/runfiles_remote_test/WORKSPACE
 +++ /dev/null
-@@ -1 +0,0 @@
+@@ -1,1 +0,0 @@
 -workspace(name = "runfiles_remote_test")
 diff --git a/tests/core/runfiles/runfiles_remote_test/remote_file.txt b/tests/core/runfiles/runfiles_remote_test/remote_file.txt
 deleted file mode 100644


### PR DESCRIPTION
The chuck header format is wrong, which doesn't work with `--incompatible_use_native_patch` in Bazel.

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
