### PR TITLE
fix: ts_auto_deps workaround for https://github.com/bazelbuild/bazel/issues/3325 no longer needed

### DIFF
--- a/ts_auto_deps/main.go
+++ b/ts_auto_deps/main.go
@@ -39,16 +39,6 @@ Flags:
 }
 
 func main() {
-	// When executed under `bazel run`, we want to run in the users workspace, not
-	// the runfiles directory of the go_binary.
-	// See https://github.com/bazelbuild/bazel/issues/3325
-	if wd := os.Getenv("BUILD_WORKING_DIRECTORY"); len(wd) > 0 {
-		err := os.Chdir(wd)
-		if err != nil {
-			platform.Error(err)
-		}
-	}
-
 	flag.Usage = usage
 	flag.Parse()
 


### PR DESCRIPTION
As part of https://github.com/bazelbuild/rules_nodejs/pull/1042.

`--direct_run` is now enabled by default in Bazel (https://github.com/bazelbuild/bazel/issues/3325#issuecomment-439815608) so this work-around is no longer needed. The work-around was creating an issue as it was forcing ts_auto_deps to run in the `BUILD_WORKING_DIRECTORY` in the `//e2e:e2e_ts_auto_deps` test that was calling `bazel run @nodejs//:bin/yarn -- generate_build_file` here: https://github.com/bazelbuild/rules_nodejs/pull/1042/files#diff-e90fea9ba9d188bc0409725ef3b89eb0
