### PR TITLE
feat(devserver): support specifying ibazel livereload script location

### DIFF
--- a/devserver/BUILD.bazel
+++ b/devserver/BUILD.bazel
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
         "main.go",
         "runfile-filesystem.go",
+        "livereload_proxy.go",
     ],
     importpath = "github.com/bazelbuild/rules_typescript/devserver",
     visibility = ["//visibility:private"],
@@ -27,6 +28,12 @@ go_library(
         "//devserver/devserver:go_default_library",
         "//devserver/runfiles:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["livereload_proxy_test.go"],
+    embed = [":go_default_library"],
 )
 
 go_binary(

--- a/devserver/livereload_proxy.go
+++ b/devserver/livereload_proxy.go
@@ -1,0 +1,64 @@
+// Main package that provides a command line interface for starting a Bazel devserver
+// using Bazel runfile resolution and ConcatJS for in-memory bundling of specified AMD files.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+// setupLivereloadProxy sets up two HTTP url handlers in order to expose the  livereload
+// script and websocket endpoint through a specific configurable URL. This is helpful
+// as "ibazel" sets up the livereload server on a unpredictable port and developers need
+// a predictable/configurable endpoint where the livereload logic is served (especially
+// if concatjs bundles are not used and the livereloading script cannot be inlined automatically)
+func setupLivereloadProxy(scriptUrl string, ibazelScriptUrl string) error {
+	// Parse the ibazel script URL in order to construct URLs that resolve to
+	// the websocket endpoint and livereload server host.
+	ibazelWebsocketUrl, err := url.Parse(ibazelScriptUrl)
+	if err != nil {
+		return fmt.Errorf("could not parse ibazel livereload url: %s", ibazelScriptUrl)
+	}
+	// this always resolves to the ibazel websocket URL. Read more about this:
+	// https://github.com/jaschaephraim/lrserver#lrserver-livereload-server-for-go
+	ibazelWebsocketUrl.Path = "/livereload"
+
+	// Clone the ibazel livereload websocket URL and build a URL that just resolves to
+	// the  livereload server host. This can be used to instantiate the reverse proxy.
+	livereloadServerUrl := *ibazelWebsocketUrl;
+	livereloadServerUrl.Path = ""
+
+	// Build a reverse proxy resolving to the ibazel livereload server.
+	reverseProxy := httputil.NewSingleHostReverseProxy(&livereloadServerUrl)
+
+	// we always need a handler for "/livereload" as the livereload script always establishes
+	// a websocket connection to that URL. This is not configurable.
+	// 	// https://github.com/jaschaephraim/lrserver#lrserver-livereload-server-for-go
+	http.Handle("/livereload", createHttpForwardHandler(reverseProxy, ibazelWebsocketUrl.String()))
+	http.Handle(scriptUrl, createHttpForwardHandler(reverseProxy, ibazelScriptUrl))
+
+	return nil
+}
+
+// createHttpForwardHandler creates an http handler that forwards all requests to a specific
+// target url through a specified reverse proxy.
+func createHttpForwardHandler(proxy *httputil.ReverseProxy, targetUrl string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyRequest, err := http.NewRequest(r.Method, targetUrl, r.Body)
+		if err != nil {
+			http.Error(w, "Could not create forwarded request.", 500)
+			return
+		}
+		copyRequestHeaders(r, proxyRequest)
+		proxy.ServeHTTP(w, proxyRequest)
+	})
+}
+
+// copyRequestHeaders copies all HTTP headers from a given request to another.
+func copyRequestHeaders(originalRequest *http.Request, newRequest *http.Request) {
+	for name, value := range originalRequest.Header {
+		newRequest.Header.Set(name, value[0])
+	}
+}

--- a/devserver/livereload_proxy_test.go
+++ b/devserver/livereload_proxy_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLivereloadProxy (t *testing.T) {
+	recorder := httptest.NewRecorder()
+	scriptRequestForwarded := false
+	websocketRequestForwarded := false
+	livereloadServerHost := "localhost:1234"
+	livereloadServerUrl := "http://" + livereloadServerHost
+
+	livereloadServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf(r.URL.String())
+		if r.URL.Path == "/livereload" {
+			websocketRequestForwarded = true
+		} else if r.URL.Path == "/livereload_1234.js" {
+			scriptRequestForwarded = true
+			w.Write([]byte("script content"))
+		}
+	}))
+
+	listener, _ := net.Listen("tcp", livereloadServerHost)
+	livereloadServer.Listener = listener
+	livereloadServer.Start()
+
+	defer livereloadServer.Close()
+
+	// setup the livereload proxy handlers.
+	err := setupLivereloadProxy("/my-livereload-script.js", livereloadServerUrl + "/livereload_1234.js")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scriptRequest := httptest.NewRequest("GET", "/my-livereload-script.js", nil)
+	wsRequest := httptest.NewRequest("GET", "/livereload", nil)
+
+	http.DefaultServeMux.ServeHTTP(recorder, scriptRequest)
+	http.DefaultServeMux.ServeHTTP(recorder, wsRequest)
+
+	if recorder.Code != 200 {
+		t.Errorf("Expected response status code to be 200, but got: %d", recorder.Code)
+	}
+
+	if scriptRequestForwarded == false {
+		t.Errorf("Expected script request to get forwarded")
+	}
+
+	if websocketRequestForwarded == false {
+		t.Errorf("Expected websocket request to get forwarded")
+	}
+
+	if recorder.Body.String() != "script content" {
+		t.Errorf("Expected forwarded request to retrieve correct response")
+	}
+}


### PR DESCRIPTION
The livereloading script from ibazel is currently served at a non-static URL. Meaning
that we can't just add a script import to the livereload script in the index.html.

If the ts_devserver uses the concatjs bundle it works because the devserver go
implementation currently reads the `IBAZEL_LIVERELOAD_URL` environment variable
and adds the script to the concatjs bundle automatically.

In the other scenario where concatjs is not used, developers need a way to specify
where the livereload script should be loaded from (meaning that there is a predictable
URL for the script). This commit adds a flag to the devserver binary that can be used to
set a specific URL where the livereloading script should be served from. This is achieved
by forwarding all request for that URL to the actual ibazel livereloading script.

References https://github.com/bazelbuild/rules_nodejs/issues/1036