### PR TITLE
Remove --incompatible_depset_is_not_iterable

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,3 @@ test --nolegacy_external_runfiles
 
 # Enable the "Managed Directories" feature
 common --experimental_allow_incremental_repository_updates
-
-# Opt-in to upcoming breaking change
-build --incompatible_depset_is_not_iterable


### PR DESCRIPTION
Remove this flag from the .bazelrc.

Bazel no longer supports this flag, see https://github.com/bazelbuild/bazel/issues/5816

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Using Bazel built from https://github.com/bazelbuild/bazel/commit/8f075d238fa099950b470da2541548d932b2b535, `bazel-head info` breaks. Culprit is Bazel no longer supports `--incompatible_depset_is_not_iterable`, added here: https://github.com/bazelbuild/rules_typescript/blob/62bbdc8b3b4f9a8222b135648e8e425e23cad056/.bazelrc#L15


Issue Number: N/A

Did not open any issue, because the bug template asks to open issues with rules_nodejs, but the bug is specific to this repo.


## What is the new behavior?

`bazel-head info` works.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
