### PR TITLE
presubmit.yml: Remove obsolete incompatible flag

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -44,6 +44,5 @@ platforms:
     test_flags:
     - "--action_env=PATH"
     - "--test_env=PATH"
-    - "--incompatible_windows_native_test_wrapper"
     test_targets:
     - "..."


### PR DESCRIPTION
Bazel 1.0.0 flipped
--incompatible_windows_native_test_wrapper and
Bazel at HEAD [1] no longer supports it, so Bazel
CI with Bazel@HEAD is now broken [2].

[1] https://github.com/bazelbuild/bazel/commits/912e822cd14710b2ebe8c7484c682d627f2906cb
[2] https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1359#386d25d4-6fc9-4d49-a0ef-b0fd82bd3dee

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
