### PR TITLE
Make rules_typescript compatible with --incompatible_load_proto_rules_from_bzl

### DIFF
--- a/third_party/github.com/bazelbuild/bazel/src/main/protobuf/BUILD.bazel
+++ b/third_party/github.com/bazelbuild/bazel/src/main/protobuf/BUILD.bazel
@@ -3,6 +3,7 @@
 # The generated `@bazel/typescript` npm package contains a trimmed BUILD file using # DEV-ONLY fences.
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//:__pkg__"])
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/bazelbuild/bazel/issues/8922
https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/402#72efd01e-eea9-47b4-827e-27edc0f3d9e8

Fixes #476

## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information