### PR TITLE
Add external_module_roots arg to create_tsconfig

### DIFF
--- a/internal/common/tsconfig.bzl
+++ b/internal/common/tsconfig.bzl
@@ -17,7 +17,6 @@
 
 load(":common/module_mappings.bzl", "get_module_mappings")
 
-
 _DEBUG = False
 
 def create_tsconfig(
@@ -33,6 +32,7 @@ def create_tsconfig(
         extra_root_dirs = [],
         module_path_prefixes = None,
         module_roots = None,
+        external_module_roots = None,
         node_modules_root = None):
     """Creates an object representing the TypeScript configuration to run the compiler under Bazel.
 
@@ -50,6 +50,7 @@ def create_tsconfig(
       extra_root_dirs: Extra root dirs to be passed to tsc_wrapped.
       module_path_prefixes: additional locations to resolve modules
       module_roots: standard locations to resolve modules
+      external_module_roots: external locations to resolve modules
       node_modules_root: the node_modules root path
 
     Returns:
@@ -117,6 +118,12 @@ def create_tsconfig(
     # so we create a new hash that contains the module_mappings and insert the
     # default lookup locations at the end.
     mapped_module_roots = {}
+
+    if external_module_roots != None:
+        # First, inject external module roots if given into the mapped module roots
+        for name, paths in external_module_roots.items():
+            mapped_module_roots[name] = paths
+
     for name, path in module_mappings.items():
         # Each module name maps to the immediate path, to resolve "index(.d).ts",
         # or module mappings that directly point to files (like index.d.ts).
@@ -161,7 +168,6 @@ def create_tsconfig(
 
     if hasattr(ctx.attr, "compile_angular_templates") and ctx.attr.compile_angular_templates:
         bazel_options["compileAngularTemplates"] = True
-
 
     if disable_strict_deps:
         bazel_options["disableStrictDeps"] = disable_strict_deps


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: https://github.com/bazelbuild/rules_nodejs/issues/1033


## What is the new behavior?
The `create_tsconfig` function now has an `external_module_roots` arg so that the `ts_library` rule can insert explicit paths into `tsconfig.json` for scoped packages. The change for `ts_library` will be made as a separate PR once this change merges in (a potential change is like so https://github.com/volkangurel/rules_nodejs/commit/04420072a11a4cbbe69e3c0f3c6c25566025def8)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A