### PR TITLE
feat: add devmodeModuleOverride to tsconfig bazelOptions

### DIFF
--- a/internal/tsc_wrapped/tsconfig.ts
+++ b/internal/tsc_wrapped/tsconfig.ts
@@ -201,6 +201,17 @@ export interface BazelOptions {
    * future.
    */
   devmodeTargetOverride?: string;
+
+  /**
+   * Override for module format to use for devmode.
+   *
+   * This setting can be set in a user's tsconfig to override the default
+   * devmode module.
+   *
+   * EXPERIMENTAL: This setting is experimental and may be removed in the
+   * future.
+   */
+  devmodeModuleOverride?: string;
 }
 
 export interface ParsedTsConfig {
@@ -285,6 +296,10 @@ export function parseTsconfig(
           devmodeTargetOverride: isUndefined(existingBazelOpts.devmodeTargetOverride)
             ? newBazelBazelOpts.devmodeTargetOverride
             : existingBazelOpts.devmodeTargetOverride,
+
+          devmodeModuleOverride: isUndefined(existingBazelOpts.devmodeModuleOverride)
+            ? newBazelBazelOpts.devmodeModuleOverride
+            : existingBazelOpts.devmodeModuleOverride,
         }
       }
 
@@ -346,7 +361,7 @@ export function parseTsconfig(
         break;
       default:
         console.error(
-            'WARNING: your tsconfig.json file specifies an invalid bazelOptions.devmodeTargetOverride value of: \'${bazelOpts.devmodeTargetOverride\'');
+            `WARNING: your tsconfig.json file specifies an invalid bazelOptions.devmodeTargetOverride value of: '${bazelOpts.devmodeTargetOverride}'`);
     }
   }
 
@@ -358,6 +373,36 @@ export function parseTsconfig(
   // If the user requested goog.module, we need to produce that output even if
   // the generated tsconfig indicates otherwise.
   if (bazelOpts.googmodule) options.module = ts.ModuleKind.CommonJS;
+
+  // If not googmodule, override the devmode module if devmodeModuleOverride is set
+  else if (bazelOpts.es5Mode && bazelOpts.devmodeModuleOverride) {
+    switch (bazelOpts.devmodeModuleOverride.toLowerCase()) {
+      case 'none':
+        options.module = ts.ModuleKind.None;
+        break;
+      case 'commonjs':
+        options.module = ts.ModuleKind.CommonJS;
+        break;
+      case 'amd':
+        options.module = ts.ModuleKind.AMD;
+        break;
+      case 'umd':
+        options.module = ts.ModuleKind.UMD;
+        break;
+      case 'system':
+        options.module = ts.ModuleKind.System;
+        break;
+      case 'es2015':
+        options.module = ts.ModuleKind.ES2015;
+        break;
+      case 'esnext':
+        options.module = ts.ModuleKind.ESNext;
+        break;
+      default:
+        console.error(
+            `WARNING: your tsconfig.json file specifies an invalid bazelOptions.devmodeModuleOverride value of: '${bazelOpts.devmodeModuleOverride}'`);
+    }
+  }
 
   // TypeScript's parseJsonConfigFileContent returns paths that are joined, eg.
   // /path/to/project/bazel-out/arch/bin/path/to/package/../../../../../../path


### PR DESCRIPTION
By default devmode module format is UMD (or CommonJS if googmodule is set). This option allows that to be overridden (if googmodule is not set).

This feature is requested by @filipesilva for the angular-cli bazel migration.

PR in rules_nodejs adds test coverage for the new tsconfig setting: https://github.com/bazelbuild/rules_nodejs/pull/1687

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
