### PR TITLE
Allow all files contained in allowed directory for strictDeps

### DIFF
--- a/internal/tsc_wrapped/strict_deps_test.ts
+++ b/internal/tsc_wrapped/strict_deps_test.ts
@@ -84,6 +84,21 @@ describe('strict deps', () => {
         .toMatch(/transitive dependency on p\/sd1.ts not allowed/);
   });
 
+  it('should not report error for transitive dependencies in allowed directory', () => {
+    const p = createProgram({
+      '/src/p/sd1.ts': 'export let x = 1;',
+      '/src/p/sd2.ts': `import {x} from "./sd1";
+          export let y = x;`,
+      '/src/d/sd3.ts': `import {y} from "../p/sd2";
+          import {x} from "../p/sd1";
+          export let z = x + y;`,
+    });
+    const diags = checkModuleDeps(
+      p.getSourceFile('d/sd3.ts')!, p.getTypeChecker(), ['/src/p'],
+      '/src');
+    expect(diags.length).toBe(0);
+  });
+
   it('reports errors for exports', () => {
     const p = createProgram({
       '/src/p/sd1.ts': 'export let x = 1;',


### PR DESCRIPTION
Currently, if you pass a directory without explicitly
enumerating all files in the directory, the strictDeps rule
will fail. This checks the path of any directories that are
allowed to see if a given files is contained to determine if
it really is transitive or not.

In essence, allow dir/** pattern for strictDeps

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
