### PR TITLE
refactor: use new label workspace_name

### DIFF
--- a/internal/common/module_mappings.bzl
+++ b/internal/common/module_mappings.bzl
@@ -122,14 +122,7 @@ module_mappings_aspect = aspect(
 # the runfiles directory. This requires the workspace_name to be prefixed on
 # each module root.
 def _module_mappings_runtime_aspect_impl(target, ctx):
-    if target.label.workspace_root:
-        # We need the workspace_name for the target being visited.
-        # Skylark doesn't have this - instead they have a workspace_root
-        # which looks like "external/repo_name" - so grab the second path segment.
-        # TODO(alexeagle): investigate a better way to get the workspace name
-        workspace_name = target.label.workspace_root.split("/")[1]
-    else:
-        workspace_name = ctx.workspace_name
+    workspace_name = target.label.workspace_name if target.label.workspace_name else ctx.workspace_name
     mappings = get_module_mappings(
         target.label,
         ctx.rule.attr,


### PR DESCRIPTION
workspace_name function was added to Label back in 0.21.0 lso we can cleanup the TODO now

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
