### PR TITLE
build: fixes downstream pkg_npm issue in rules_nodejs when making @bazel/typescript package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,6 +38,7 @@ pkg_npm(
         "//internal:npm_package_assets",
         "//third_party/github.com/bazelbuild/bazel/src/main/protobuf:npm_package_assets",
     ],
+    vendor_external = ["build_bazel_rules_typescript"],
     visibility = ["//visibility:public"],
     deps = [
         "//devserver:devserver-darwin",


### PR DESCRIPTION
We're already patching this in rules_nodejs for our release. This will allows us to remove the patch https://github.com/bazelbuild/rules_nodejs/blob/1.4.0/rules_typescript.patch.

Should not affect g3 at all as this BUILD file is not synced.