### PR TITLE
Handle a case where TS asks for no types to be resolved

### DIFF
--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -398,7 +398,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
    * looking under `bazelOpts.nodeModulesPrefix`
    */
   resolveTypeReferenceDirectives(names: string[], containingFile: string): ts.ResolvedTypeReferenceDirective[] {
-    if (!this.allowActionInputReads) return [];
+    if (!this.allowActionInputReads || !names) return [];
     const result: ts.ResolvedTypeReferenceDirective[] = [];
     names.forEach(name => {
       let resolved: ts.ResolvedTypeReferenceDirective | undefined;


### PR DESCRIPTION
Stack trace looks like
```
Compilation failed TypeError: Cannot read property 'forEach' of undefined
    at internal/tsc_wrapped/compiler_host.js:333:36
    at Array.forEach (<anonymous>)
    at CompilerHost.resolveTypeReferenceDirectives (internal/tsc_wrapped/compiler_host.js:330:15)
    at resolveTypeReferenceDirectiveNamesWorker (node_modules/typescript/lib/typescript.js:95088:137)
    at Object.createProgram (node_modules/typescript/lib/typescript.js:95174:35)
    at internal/tsc_wrapped/tsc_wrapped.js:319:62
    at Object.wrap (internal/tsc_wrapped/perf_trace.js:35:16)
    at createProgramAndEmit (internal/tsc_wrapped/tsc_wrapped.js:319:31)
    at runOneBuild (internal/tsc_wrapped/tsc_wrapped.js:218:33)
    at Object.<anonymous> (internal/tsc_wrapped/worker.js:164:49)
```