### PR TITLE
Remove deprecated flag from bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,3 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 # Turn off legacy external runfiles
 run --nolegacy_external_runfiles
 test --nolegacy_external_runfiles
-
-# Enable the "Managed Directories" feature
-common --experimental_allow_incremental_repository_updates


### PR DESCRIPTION
--experimental_allow_incremental_repository_updates has been deleted in https://github.com/bazelbuild/bazel/commit/fdf10c34c82c563fb7fc7f262de32e1f7af59e2d
