### PR TITLE
fix: tsetse checker must be initialized with latest program

### DIFF
--- a/internal/tsetse/language_service_plugin.ts
+++ b/internal/tsetse/language_service_plugin.ts
@@ -10,26 +10,25 @@ function init() {
   return {
     create(info: ts.server.PluginCreateInfo) {
       const oldService = info.languageService;
-      const program = oldService.getProgram();
-
-      // Signature of `getProgram` is `getProgram(): Program | undefined;` in
-      // ts 3.1 so we must check if the return value is valid to compile with
-      // ts 3.1.
-      if (!program) {
-        throw new Error(
-            'Failed to initialize tsetse language_service_plugin: program is undefined');
-      }
-
-      const checker = new Checker(program);
-
-      // Add disabledRules to tsconfig to disable specific rules
-      // "plugins": [
-      //   {"name": "...", "disabledRules": ["equals-nan"]}
-      // ]
-      registerRules(checker, info.config.disabledRules || []);
-
       const proxy = pluginApi.createProxy(oldService);
       proxy.getSemanticDiagnostics = (fileName: string) => {
+        const program = oldService.getProgram();
+
+        // Signature of `getProgram` is `getProgram(): Program | undefined;` in
+        // ts 3.1 so we must check if the return value is valid to compile with
+        // ts 3.1.
+        if (!program) {
+          throw new Error(
+              'Failed to initialize tsetse language_service_plugin: program is undefined');
+        }
+
+        const checker = new Checker(program);
+
+        // Add disabledRules to tsconfig to disable specific rules
+        // "plugins": [
+        //   {"name": "...", "disabledRules": ["equals-nan"]}
+        // ]
+        registerRules(checker, info.config.disabledRules || []);
         const result = [...oldService.getSemanticDiagnostics(fileName)];
         // Note that this ignores suggested fixes.
         result.push(...checker.execute(program.getSourceFile(fileName)!)


### PR DESCRIPTION
Since ts.Program is an immutable data structure, the tsetse checker
must get hold of a new instance of the ts.Program every time
`getSemanticDiagnostics` is called. There is no way to do this currently,
so just create a new tsetse Checker instance every time.

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
