### PR TITLE
Fix rules_go dependency

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -48,9 +48,14 @@ def rules_typescript_dev_dependencies():
         http_archive,
         name = "io_bazel_rules_go",
         patch_args = ["-p1"],
-        # Patch out a breaking change to runfiles support library
-        # See discussion on https://github.com/bazelbuild/rules_go/pull/2076
-        patches = ["@build_bazel_rules_typescript//:revert_rules_go_commit_4442d82a001f378d0605cbbca3fb529979a1c3a6.patch"],
+        patches = [
+            # Patch out a breaking change to runfiles support library
+            # See discussion on https://github.com/bazelbuild/rules_go/pull/2076
+            "@build_bazel_rules_typescript//:revert_rules_go_commit_4442d82a001f378d0605cbbca3fb529979a1c3a6.patch",
+            # This old SHA seems no longer available on go.googlesource.com?
+            # Fetching @org_golang_x_tools; Cloning c8855242db9c1762032abe33c2dff50de3ec9d05 of https://go.googlesource.com/tools 99s
+            "@build_bazel_rules_typescript//:replace_go_googlesource_com_remote.patch",
+        ],
         sha256 = "8df59f11fb697743cbb3f26cfb8750395f30471e9eabde0d174c3aebc7a1cd39",
         urls = [
             "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz",

--- a/replace_go_googlesource_com_remote.patch
+++ b/replace_go_googlesource_com_remote.patch
@@ -1,0 +1,13 @@
+diff --git a/go/private/repositories.bzl b/go/private/repositories.bzl
+index 5649c31b..06f48769 100644
+--- a/go/private/repositories.bzl
++++ b/go/private/repositories.bzl
+@@ -61,7 +61,7 @@ def go_rules_dependencies():
+     _maybe(
+         git_repository,
+         name = "org_golang_x_tools",
+-        remote = "https://go.googlesource.com/tools",
++        remote = "https://github.com/golang/tools.git",
+         # "latest", as of 2019-07-08
+         commit = "c8855242db9c1762032abe33c2dff50de3ec9d05",
+         shallow_since = "1562618051 +0000",


### PR DESCRIPTION
Somehow for me this git fetch from go.googlesource.com times out after 5 minutes, after trying many times over the last week.
This URL works
https://go.googlesource.com/tools/+/c8855242db9c1762032abe33c2dff50de3ec9d05
so I'm not sure how to explain/reproduce why I can't fetch this but the CI is passing.

This ends up blocking rules_nodejs from cutting a release.

*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.
