### PR TITLE
Add type assertion to JSON.parse.

### DIFF
--- a/internal/tsc_wrapped/compiler_host.ts
+++ b/internal/tsc_wrapped/compiler_host.ts
@@ -24,6 +24,10 @@ export interface BazelTsOptions extends ts.CompilerOptions {
   typeRoots: string[];
 }
 
+declare interface packageJson {
+  typings?: string;
+}
+
 export function narrowTsOptions(options: ts.CompilerOptions): BazelTsOptions {
   if (!options.rootDirs) {
     throw new Error(`compilerOptions.rootDirs should be set by tsconfig.bzl`);
@@ -369,7 +373,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
     // if it exists
     const pkgFile = path.posix.join(typePath, 'package.json');
     if (this.fileExists(pkgFile)) {
-      const pkg = JSON.parse(fs.readFileSync(pkgFile, 'UTF-8'));
+      const pkg = JSON.parse(fs.readFileSync(pkgFile, 'UTF-8')) as packageJson;
       let typings = pkg['typings'];
       if (typings) {
         if (typings === '.' || typings === './') {


### PR DESCRIPTION
*Attention Googlers:* This repo has its Source of Truth in Piper. After sending a PR, you can follow http://g3doc/third_party/bazel_rules/rules_typescript/README.google.md#merging-changes to get your change merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

With the new JSON.parse rule (https://github.com/bazelbuild/rules_typescript/blob/6a1591b8728f0adb0bda02116801b9b992475035/internal/tsetse/rules/must_type_assert_json_parse_rule.ts), compiler_host fails to compile running under tsetse.


Issue Number: N/A


## What is the new behavior?

No new behavior; purely a types change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
