### PR TITLE
fix: remove incompatible license attribute from compilation

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,5 @@
 ---
-bazel: 2.1.0
+bazel: 3.0.0
 platforms:
   ubuntu1604:
     run_targets:

--- a/internal/common/compilation.bzl
+++ b/internal/common/compilation.bzl
@@ -44,7 +44,6 @@ COMMON_ATTRIBUTES = {
     "expected_diagnostics": attr.string_list(),
     # Whether to generate externs.js from any "declare" statement.
     "generate_externs": attr.bool(default = True),
-    "licenses": attr.license(),
     # Used to determine module mappings
     "module_name": attr.string(),
     "module_root": attr.string(),


### PR DESCRIPTION
In the past, the `license` attribute has been added. This attribute seems to be no longer available in the latest versions of Bazel. The attribute is only available with the "no-incompatible" Bazel command line flag. See: https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java;l=395-405?q=incompatible_no_attr_license&ss=bazel.

We should make sure the rules are compatible with the most recent versions of Bazel.